### PR TITLE
Set DS namespace to ppc namespace

### DIFF
--- a/controllers/poisonpillconfig_controller.go
+++ b/controllers/poisonpillconfig_controller.go
@@ -82,6 +82,7 @@ func (r *PoisonPillConfigReconciler) syncConfigDaemonSet(ppc *poisonpillv1alpha1
 
 	data := render.MakeRenderData()
 	data.Data["Image"] = os.Getenv("POISON_PILL_IMAGE")
+	data.Data["Namespace"] = ppc.Namespace
 	objs, err := render.RenderDir(r.InstallFileFolder, &data)
 	if err != nil {
 		logger.Error(err, "Fail to render config daemon manifests")

--- a/install/poison-pill-deamonset.yaml
+++ b/install/poison-pill-deamonset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: poison-pill-ds
-  namespace: poison-pill
+  namespace: {{.Namespace}}
   labels:
     k8s-app: poison-pill
 spec:


### PR DESCRIPTION
This allows the user to set the ns of the DS.
Practically I needed that to run in the "operators" ns which is what operatorhub suggests. otherwise, it would fail on "cross namespace owner ref are not allowed"

we might need a better solution in the future