### PR TITLE
use 0.0.1 image in 0.1 branch

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -26,7 +26,7 @@ spec:
               fieldRef:
                 fieldPath: spec.nodeName
           - name: POISON_PILL_IMAGE
-            value: quay.io/medik8s/poison-pill-operator:latest
+            value: quay.io/medik8s/poison-pill-operator:0.0.1
         args:
           - "--health-probe-bind-address=:8081"
           - "--metrics-bind-address=127.0.0.1:8080"

--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -15,4 +15,4 @@ env:
       fieldRef:
         fieldPath: spec.nodeName
   - name: POISON_PILL_IMAGE
-    value: quay.io/medik8s/poison-pill-operator:latest
+    value: quay.io/medik8s/poison-pill-operator:0.0.1


### PR DESCRIPTION
I'm aware that 0.0.1 and 0.1 don't match, we will first need to update operatorhub to use 0.1.0, then we can use 0.1.0 here as well