### PR TITLE
Specify the ext cluster role in kustomiztion.yaml

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- external_remediation_clusterrole.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.


### PR DESCRIPTION
Signed-off-by: Roy Golan <rgolan@redhat.com>

- Specify the ext cluster role in kustomization.yaml

without that, `make deploy` and `make bundle`, etc. won't use the external cluster role at all
