### PR TITLE
Add 'list' verb for remediations in the role aggregator

### DIFF
--- a/config/rbac/external_remediation_clusterrole.yaml
+++ b/config/rbac/external_remediation_clusterrole.yaml
@@ -17,6 +17,7 @@ rules:
       - poisonpillremediations
     verbs:
       - get
+      - list
       - create
       - delete
 


### PR DESCRIPTION
Without this NHC can not calculate in-flight remediations

Signed-off-by: Roy Golan <rgolan@redhat.com>
