### PR TITLE
Configurable watchdog path and node reboot timeout

### DIFF
--- a/api/v1alpha1/poisonpillconfig_types.go
+++ b/api/v1alpha1/poisonpillconfig_types.go
@@ -29,6 +29,7 @@ type PoisonPillConfigSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// WatchdogFilePath is the watchdog file path that should be available on each node, e.g. /dev/watchdog
+	// +kubebuilder:default=/dev/watchdog1
 	WatchdogFilePath string `json:"watchdogFilePath,omitempty"`
 
 	// SafeTimeToAssumeNodeRebootedSeconds is the time after which the healthy poison pill
@@ -36,6 +37,7 @@ type PoisonPillConfigSpec struct {
 	// from the cluster. This is extremely important. Deleting a node while the workload is still
 	// running there might lead to data corruption and violation of run-once semantic.
 	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:default=180
 	SafeTimeToAssumeNodeRebootedSeconds int `json:"safeTimeToAssumeNodeRebootedSeconds,omitempty"`
 }
 

--- a/config/crd/bases/poison-pill.medik8s.io_poisonpillconfigs.yaml
+++ b/config/crd/bases/poison-pill.medik8s.io_poisonpillconfigs.yaml
@@ -40,6 +40,7 @@ spec:
             description: PoisonPillConfigSpec defines the desired state of PoisonPillConfig
             properties:
               safeTimeToAssumeNodeRebootedSeconds:
+                default: 180
                 description: SafeTimeToAssumeNodeRebootedSeconds is the time after
                   which the healthy poison pill agents will assume the unhealthy node
                   has been rebooted and it is safe to remove the node from the cluster.
@@ -49,6 +50,7 @@ spec:
                 minimum: 0
                 type: integer
               watchdogFilePath:
+                default: /dev/watchdog1
                 description: WatchdogFilePath is the watchdog file path that should
                   be available on each node, e.g. /dev/watchdog
                 type: string

--- a/controllers/controller_test.go
+++ b/controllers/controller_test.go
@@ -114,6 +114,7 @@ var _ = Describe("ppr Controller", func() {
 
 		now := time.Now()
 		It("Update ppr time to accelerate the progress", func() {
+			safeTimeToAssumeNodeRebooted := 90 * time.Second
 			oldTime := now.Add(-safeTimeToAssumeNodeRebooted).Add(-time.Minute)
 			oldTimeConverted := metav1.NewTime(oldTime)
 			ppr.Status.TimeAssumedRebooted = &oldTimeConverted

--- a/controllers/poisonpillconfig_controller.go
+++ b/controllers/poisonpillconfig_controller.go
@@ -83,6 +83,9 @@ func (r *PoisonPillConfigReconciler) syncConfigDaemonSet(ppc *poisonpillv1alpha1
 	data := render.MakeRenderData()
 	data.Data["Image"] = os.Getenv("POISON_PILL_IMAGE")
 	data.Data["Namespace"] = ppc.Namespace
+	data.Data["WatchdogPath"] = ppc.Spec.WatchdogFilePath
+	data.Data["TimeToAssumeNodeRebooted"] = fmt.Sprintf("\"%d\"", ppc.Spec.SafeTimeToAssumeNodeRebootedSeconds)
+
 	objs, err := render.RenderDir(r.InstallFileFolder, &data)
 	if err != nil {
 		logger.Error(err, "Fail to render config daemon manifests")

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -117,10 +117,11 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&PoisonPillRemediationReconciler{
-		Client:    k8sManager.GetClient(),
-		Log:       ctrl.Log.WithName("controllers").WithName("poison-pill-remediation-controller"),
-		ApiReader: &apiReaderWrapper,
-		Watchdog:  dummyDog,
+		Client:                       k8sManager.GetClient(),
+		Log:                          ctrl.Log.WithName("controllers").WithName("poison-pill-remediation-controller"),
+		ApiReader:                    &apiReaderWrapper,
+		Watchdog:                     dummyDog,
+		SafeTimeToAssumeNodeRebooted: 90 * time.Second,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/install/poison-pill-deamonset.yaml
+++ b/install/poison-pill-deamonset.yaml
@@ -28,6 +28,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: WATCHDOG_PATH
+            value: {{.WatchdogPath}}
+          - name: TIME_TO_ASSUME_NODE_REBOOTED
+            value: {{.TimeToAssumeNodeRebooted}}
         image: {{.Image}}
         imagePullPolicy: Always
         securityContext:

--- a/pkg/watchdog/linux.go
+++ b/pkg/watchdog/linux.go
@@ -13,8 +13,8 @@ import (
 	"github.com/go-logr/logr"
 )
 
-const (
-	watchdogDevice = "/dev/watchdog1"
+var (
+	watchdogDevice = os.Getenv("WATCHDOG_PATH")
 )
 
 // ensure we only have 1 instance


### PR DESCRIPTION
Add support for configuring watchdog device file path and safe time assume unhealthy node has been rebooted.