### PR TITLE
Add a finalizer to avoid ppr deletion while remediation is ongoing

### DIFF
--- a/api/v1alpha1/poisonpillremediation_types.go
+++ b/api/v1alpha1/poisonpillremediation_types.go
@@ -37,6 +37,7 @@ type PoisonPillRemediationStatus struct {
 	// +optional
 	// +kubebuilder:validation:EmbeddedResource
 	// +kubebuilder:pruning:PreserveUnknownFields
+	// +nullable
 	NodeBackup *v1.Node `json:"nodeBackup,omitempty"`
 
 	//TimeAssumedRebooted is the time by then the unhealthy node assumed to be rebooted

--- a/config/crd/bases/poison-pill.medik8s.io_poisonpillremediations.yaml
+++ b/config/crd/bases/poison-pill.medik8s.io_poisonpillremediations.yaml
@@ -47,6 +47,7 @@ spec:
               nodeBackup:
                 description: NodeBackup is the node object that is going to be deleted
                   as part of the remediation process
+                nullable: true
                 properties:
                   apiVersion:
                     description: 'APIVersion defines the versioned schema of this


### PR DESCRIPTION
without a finalizer we got stuck at the middle of remediation and left with a node with an unschedulable taint.
This only continues the remediation as if the ppr was never deleted and this prevents the node/machine get stuck in the middle of remediation.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1966140