### PR TITLE
fix broken watchdog which could not be initialized

### DIFF
--- a/main.go
+++ b/main.go
@@ -113,9 +113,12 @@ func main() {
 
 		timeToAssumeNodeRebootedDur := time.Duration(timeToAssumeNodeRebootedInt) * time.Second
 
-		buffer := time.Second * 5
-		if timeToAssumeNodeRebootedDur < watchdog.GetTimeout()+buffer {
-			timeToAssumeNodeRebootedDur = watchdog.GetTimeout() + buffer
+		if watchdog != nil {
+			//if we use watchdog, let's make sure the timeout to delete a node is bigger than the wd timeout
+			buffer := time.Second * 5
+			if timeToAssumeNodeRebootedDur < watchdog.GetTimeout()+buffer {
+				timeToAssumeNodeRebootedDur = watchdog.GetTimeout() + buffer
+			}
 		}
 
 		if err = (&controllers.PoisonPillRemediationReconciler{

--- a/pkg/watchdog/linux.go
+++ b/pkg/watchdog/linux.go
@@ -18,7 +18,7 @@ var (
 )
 
 // ensure we only have 1 instance
-var once sync.Once
+var mutex sync.Mutex
 var linuxWatchDogInstantiated = false
 
 var _ watchdogImpl = &linuxWatchdog{}
@@ -37,11 +37,13 @@ type watchdogInfo struct {
 }
 
 func NewLinux(log logr.Logger) (Watchdog, error) {
-
-	once.Do(func() { linuxWatchDogInstantiated = true })
+	mutex.Lock()
 	if linuxWatchDogInstantiated {
 		return nil, fmt.Errorf("linux watchdog already instantiated")
 	}
+
+	linuxWatchDogInstantiated = true
+	mutex.Unlock()
 
 	if _, err := os.Stat(watchdogDevice); err != nil {
 		if os.IsNotExist(err) {


### PR DESCRIPTION
The existing code sets `linuxWatchDogInstantiated` to `true` and later doesn't allow creation of any watchdog, which means that we can even create a single watchdog.

From the log:
```
2021-06-07T18:28:35.375Z        INFO    setup   Starting as a poison pill agent that should run as part of the daemonset
2021-06-07T18:28:35.375Z        ERROR   setup   failed to init watchdog, using soft reboot      {"error": "linux watchdog already instantiated"}
```

also fixed in a separate commit - don't check for watchdog timeout if wd is nil