### PR TITLE
API check loop

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -29,7 +29,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -48,7 +47,6 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
 var k8sClient *K8sClientWrapper
 var testEnv *envtest.Environment
 var dummyDog watchdog.Watchdog
@@ -149,7 +147,7 @@ var _ = BeforeSuite(func() {
 
 	peers := peers.New(unhealthyNodeName, peerUpdateInterval, k8sClient, ctrl.Log.WithName("peers"))
 
-	apiCheck := apicheck.New(unhealthyNodeName, peers, rebooter, apiCheckInterval, maxErrorThreshold, k8sClient, ctrl.Log.WithName("api-check"))
+	apiCheck := apicheck.New(unhealthyNodeName, peers, rebooter, apiCheckInterval, maxErrorThreshold, cfg, ctrl.Log.WithName("api-check"))
 
 	timeToAssumeNodeRebooted := time.Duration(maxErrorThreshold) * apiCheckInterval
 	timeToAssumeNodeRebooted += dummyDog.GetTimeout()

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4
 	k8s.io/api v0.20.2
+	k8s.io/apiextensions-apiserver v0.20.1
 	k8s.io/apimachinery v0.20.2
 	k8s.io/client-go v0.20.2
 	sigs.k8s.io/controller-runtime v0.8.3

--- a/main.go
+++ b/main.go
@@ -129,7 +129,7 @@ func main() {
 		apiCheckInterval := 15 * time.Second
 		maxErrorThreshold := 3
 		// use API reader for not using the cache, which would prevent detecting API errors
-		apiCheck := apicheck.New(myNodeName, myPeers, rebooter, apiCheckInterval, maxErrorThreshold, mgr.GetAPIReader(), ctrl.Log.WithName("api-check"))
+		apiCheck := apicheck.New(myNodeName, myPeers, rebooter, apiCheckInterval, maxErrorThreshold, mgr.GetConfig(), ctrl.Log.WithName("api-check"))
 		if err = mgr.Add(apiCheck); err != nil {
 			setupLog.Error(err, "failed to add api-check to the manager")
 			os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func main() {
 		rebooter := reboot.NewWatchdogRebooter(watchdog, ctrl.Log.WithName("rebooter"))
 
 		// TODO make the interval configurable
-		peerUpdateInterval := 15 * time.Second
+		peerUpdateInterval := 15 * time.Minute
 		myPeers := peers.New(myNodeName, peerUpdateInterval, mgr.GetClient(), ctrl.Log.WithName("peers"))
 		if err = mgr.Add(myPeers); err != nil {
 			setupLog.Error(err, "failed to add peers to the manager")

--- a/pkg/apicheck/check.go
+++ b/pkg/apicheck/check.go
@@ -127,6 +127,7 @@ func (c *ApiConnectivityCheck) handleError() bool {
 	}
 
 	apiErrorsResponsesSum := 0
+	nrAllNodes := len(nodesToAsk)
 	// nodesToAsk is being reduced in every iteration, iterate until no nodes left to ask
 	for i := 0; len(nodesToAsk) > 0; i++ {
 
@@ -164,7 +165,7 @@ func (c *ApiConnectivityCheck) handleError() bool {
 		if apiErrorsResponses > 0 {
 			apiErrorsResponsesSum += apiErrorsResponses
 			//todo consider using [m|n]hc.spec.maxUnhealthy instead of 50%
-			if apiErrorsResponsesSum > len(c.peers.GetPeers().Items)/2 { //already reached more than 50% of the nodes and all of them returned api error
+			if apiErrorsResponsesSum > nrAllNodes/2 { //already reached more than 50% of the nodes and all of them returned api error
 				//assuming this is a control plane failure as others can't access api-server as well
 				c.log.Info("More than 50% of the nodes couldn't access the api-server, assuming this is a control plane failure")
 				return true

--- a/pkg/apicheck/check.go
+++ b/pkg/apicheck/check.go
@@ -1,0 +1,254 @@
+package apicheck
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	poisonPill "github.com/medik8s/poison-pill/api"
+	"github.com/medik8s/poison-pill/pkg/peers"
+	"github.com/medik8s/poison-pill/pkg/reboot"
+)
+
+const (
+	// TODO make some of this configurable?
+	apiServerTimeout = 5 * time.Second
+	peerProtocol     = "http"
+	peerPort         = 30001
+	peerTimeout      = 10 * time.Second
+)
+
+type ApiConnectivityCheck struct {
+	client.Reader
+	log                logr.Logger
+	checkInterval      time.Duration
+	maxErrorsThreshold int
+	errorCount         int
+	myNodeName         string
+	peers              *peers.Peers
+	rebooter           reboot.Rebooter
+	httpClient         *http.Client
+	nodeKey            client.ObjectKey
+}
+
+func New(myNodeName string, p *peers.Peers, r reboot.Rebooter, checkInterval time.Duration, maxErrorsThreshold int, reader client.Reader, log logr.Logger) *ApiConnectivityCheck {
+	return &ApiConnectivityCheck{
+		Reader:             reader,
+		log:                log,
+		myNodeName:         myNodeName,
+		checkInterval:      checkInterval,
+		maxErrorsThreshold: maxErrorsThreshold,
+		peers:              p,
+		rebooter:           r,
+		httpClient:         &http.Client{Timeout: peerTimeout},
+		nodeKey: client.ObjectKey{
+			Name: myNodeName,
+		},
+	}
+}
+
+func (c *ApiConnectivityCheck) Start(ctx context.Context) error {
+
+	go wait.UntilWithContext(ctx, func(ctx context.Context) {
+		c.checkApi(ctx)
+	}, c.checkInterval)
+
+	c.log.Info("api connectivty check started")
+
+	<-ctx.Done()
+	return nil
+}
+
+func (c *ApiConnectivityCheck) checkApi(ctx context.Context) {
+	readerCtx, cancel := context.WithTimeout(ctx, apiServerTimeout)
+	defer cancel()
+
+	// get our own node as api server check
+	// TODO check if there is a cheaper call
+	node := &v1.Node{}
+	if err := c.Get(readerCtx, c.nodeKey, node); err != nil {
+		c.log.Error(err, "failed to check api server")
+		if isHealthy := c.handleError(err); !isHealthy {
+			// we have a problem on this node
+			c.log.Error(err, "we are unhealthy, triggering a reboot")
+			if err := c.rebooter.Reboot(); err != nil {
+				c.log.Error(err, "failed to trigger reboot")
+			}
+		} else {
+			c.log.Error(err, "peers did not confirm that we are unhealthy, ignoring error")
+		}
+		return
+	}
+	// reset error count after a successful API call!
+	c.errorCount = 0
+}
+
+// HandleError keeps track of the number of errors reported, and when a certain amount of error occur within a certain
+// time, ask peers if this node is healthy. Returns if the node is considered to be healthy or not.
+func (c *ApiConnectivityCheck) handleError(newError error) bool {
+
+	c.errorCount++
+	if c.errorCount < c.maxErrorsThreshold {
+		c.log.Info("Ignoring api-server error, error count below threshold", "current count", c.errorCount, "threshold", c.maxErrorsThreshold)
+		return true
+	}
+
+	c.log.Info("Error count exceeds threshold, trying to ask other nodes if I'm healthy")
+	nodesToAsk := c.peers.GetPeers().Items
+	if nodesToAsk == nil || len(nodesToAsk) == 0 {
+		c.log.Info("Peers list is empty and / or couldn't be retrieved from server, nothing we can do, so consider the node being healthy")
+		//todo maybe we need to check if this happens too much and reboot
+		return true
+	}
+
+	apiErrorsResponsesSum := 0
+	// nodesToAsk is being reduced in every iteration, iterate until no nodes left to ask
+	for i := 0; len(nodesToAsk) > 0; i++ {
+
+		// start asking a few nodes only in first iteration to cover the case we get a healthy / unhealthy result
+		nodesBatchCount := 3
+		if i > 0 {
+			// after that ask 10% of the cluster each time to check the api problem case
+			nodesBatchCount = len(nodesToAsk) / 10
+			if nodesBatchCount == 0 {
+				nodesBatchCount = 1
+			}
+		}
+
+		chosenNodesAddresses := c.popNodes(&nodesToAsk, nodesBatchCount)
+		nrAddresses := len(chosenNodesAddresses)
+		responsesChan := make(chan poisonPill.HealthCheckResponse, nrAddresses)
+
+		for _, address := range chosenNodesAddresses {
+			go c.getHealthStatusFromPeer(address, responsesChan)
+		}
+
+		healthyResponses, unhealthyResponses, apiErrorsResponses, _ := c.sumPeersResponses(nodesBatchCount, responsesChan)
+
+		if healthyResponses > 0 {
+			c.log.Info("Peer told me I'm healthy.")
+			c.errorCount = 0
+			return true
+		}
+
+		if unhealthyResponses > 0 {
+			c.log.Info("Peer told me I'm unhealthy!")
+			return false
+		}
+
+		if apiErrorsResponses > 0 {
+			apiErrorsResponsesSum += apiErrorsResponses
+			//todo consider using [m|n]hc.spec.maxUnhealthy instead of 50%
+			if apiErrorsResponsesSum > len(c.peers.GetPeers().Items)/2 { //already reached more than 50% of the nodes and all of them returned api error
+				//assuming this is a control plane failure as others can't access api-server as well
+				c.log.Info("More than 50% of the nodes couldn't access the api-server, assuming this is a control plane failure")
+				return true
+			}
+		}
+
+	}
+
+	//we asked all peers
+	c.log.Error(fmt.Errorf("failed health check"), "Failed to get health status peers. Assuming unhealthy")
+	return false
+}
+
+func (c *ApiConnectivityCheck) popNodes(nodes *[]v1.Node, count int) []string {
+	nrOfNodes := len(*nodes)
+	if nrOfNodes == 0 {
+		return []string{}
+	}
+
+	if count > nrOfNodes {
+		count = nrOfNodes
+	}
+
+	//todo maybe we should pick nodes randomly rather than relying on the order returned from api-server
+	addresses := make([]string, count)
+	for i := 0; i < count; i++ {
+		node := (*nodes)[i]
+		if len(node.Status.Addresses) == 0 || node.Status.Addresses[0].Address == "" {
+			c.log.Info("could not get address from node", "node", node.Name)
+			continue
+		}
+		addresses[i] = node.Status.Addresses[0].Address //todo node might have multiple addresses or none
+	}
+
+	*nodes = (*nodes)[count:] //remove popped nodes from the list
+
+	return addresses
+}
+
+//getHealthStatusFromPeer issues a GET request to the specified IP and returns the result from the peer into the given channel
+func (c *ApiConnectivityCheck) getHealthStatusFromPeer(endpointIp string, results chan<- poisonPill.HealthCheckResponse) {
+	url := fmt.Sprintf("%s://%s:%d/health/%s", peerProtocol, endpointIp, peerPort, c.myNodeName)
+
+	resp, err := c.httpClient.Get(url)
+	if err != nil {
+		c.log.Error(err, "failed to get health status from peer", "url", url)
+		results <- poisonPill.RequestFailed
+		return
+	}
+
+	defer func() {
+		if err = resp.Body.Close(); err != nil {
+			c.log.Error(err, "failed to close health response from peer")
+		}
+	}()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		c.log.Error(err, "failed to read health response from peer")
+		results <- -1
+		return
+	}
+
+	healthStatusResult, err := strconv.Atoi(string(body))
+
+	if err != nil {
+		c.log.Error(err, "failed to convert health check response from string to int")
+	}
+
+	results <- poisonPill.HealthCheckResponse(healthStatusResult)
+	return
+}
+
+func (c *ApiConnectivityCheck) sumPeersResponses(nodesBatchCount int, responsesChan chan poisonPill.HealthCheckResponse) (int, int, int, int) {
+	healthyResponses := 0
+	unhealthyResponses := 0
+	apiErrorsResponses := 0
+	noResponse := 0
+
+	for i := 0; i < nodesBatchCount; i++ {
+		response := <-responsesChan
+		c.log.Info("got response from peer", "response", response)
+
+		switch response {
+		case poisonPill.Unhealthy:
+			unhealthyResponses++
+			break
+		case poisonPill.Healthy:
+			healthyResponses++
+			break
+		case poisonPill.ApiError:
+			apiErrorsResponses++
+			break
+		case poisonPill.RequestFailed:
+			noResponse++
+		default:
+			c.log.Error(fmt.Errorf("unexpected response"),
+				"Received unexpected value from peer while trying to retrieve health status", "value", response)
+		}
+	}
+
+	return healthyResponses, unhealthyResponses, apiErrorsResponses, noResponse
+}

--- a/pkg/peers/peers.go
+++ b/pkg/peers/peers.go
@@ -35,6 +35,7 @@ func New(myNodeName string, peerUpdateInterval time.Duration, reader client.Read
 	return &Peers{
 		Reader:             reader,
 		log:                log,
+		peerList:           &v1.NodeList{},
 		peerUpdateInterval: peerUpdateInterval,
 		myNodeName:         myNodeName,
 		mutex:              sync.Mutex{},

--- a/pkg/peers/peers.go
+++ b/pkg/peers/peers.go
@@ -3,9 +3,7 @@ package peers
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"strconv"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -16,19 +14,11 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	poisonPill "github.com/medik8s/poison-pill/api"
-	"github.com/medik8s/poison-pill/pkg/reboot"
 )
 
 const (
 	hostnameLabelName = "kubernetes.io/hostname"
-
-	// TODO make some of this configurable?
-	apiServerTimeout = 5 * time.Second
-	peerProtocol     = "http"
-	peerPort         = 30001
-	peerTimeout      = 10 * time.Second
+	apiServerTimeout  = 5 * time.Second
 )
 
 type Peers struct {
@@ -37,22 +27,17 @@ type Peers struct {
 	peerList           *v1.NodeList
 	peerSelector       labels.Selector
 	peerUpdateInterval time.Duration
-	maxErrorsThreshold int
 	myNodeName         string
-	rebooter           reboot.Rebooter
-	errorCount         int
-	httpClient         *http.Client
+	mutex              sync.Mutex
 }
 
-func New(myNodeName string, r reboot.Rebooter, peerUpdateInterval time.Duration, maxErrorsThreshold int, reader client.Reader, log logr.Logger) *Peers {
+func New(myNodeName string, peerUpdateInterval time.Duration, reader client.Reader, log logr.Logger) *Peers {
 	return &Peers{
 		Reader:             reader,
 		log:                log,
 		peerUpdateInterval: peerUpdateInterval,
-		maxErrorsThreshold: maxErrorsThreshold,
 		myNodeName:         myNodeName,
-		rebooter:           r,
-		httpClient:         &http.Client{Timeout: peerTimeout},
+		mutex:              sync.Mutex{},
 	}
 }
 
@@ -91,6 +76,9 @@ func (p *Peers) Start(ctx context.Context) error {
 }
 
 func (p *Peers) updatePeers(ctx context.Context) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
 	readerCtx, cancel := context.WithTimeout(ctx, apiServerTimeout)
 	defer cancel()
 
@@ -102,180 +90,15 @@ func (p *Peers) updatePeers(ctx context.Context) {
 			p.peerList = &v1.NodeList{}
 		}
 		p.log.Error(err, "failed to update peer list")
-		if isHealthy := p.handleError(); !isHealthy {
-			// we have a problem on this node
-			p.log.Error(err, "we are unhealthy, triggering a reboot")
-			if err := p.rebooter.Reboot(); err != nil {
-				p.log.Error(err, "failed to trigger reboot")
-			}
-		} else {
-			p.log.Error(err, "peers did not confirm that we are unhealthy, ignoring error")
-		}
 		return
 	}
-	// reset error count after a successful API call!
-	p.errorCount = 0
 	//p.log.Info("peers updated")
 	p.peerList = nodes
 }
 
-// HandleError keeps track of the number of errors reported, and when a certain amount of error occur within a certain
-// time, ask peers if this node is healthy. Returns if the node is considered to be healthy or not.
-func (p *Peers) handleError() bool {
+func (p *Peers) GetPeers() *v1.NodeList {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
 
-	p.errorCount++
-	if p.errorCount < p.maxErrorsThreshold {
-		p.log.Info("Ignoring api-server error, error count below threshold", "current count", p.errorCount, "threshold", p.maxErrorsThreshold)
-		return true
-	}
-
-	p.log.Info("Error count exceeds threshold, trying to ask other nodes if I'm healthy")
-	nodesToAsk := p.peerList.Items
-	if nodesToAsk == nil || len(nodesToAsk) == 0 {
-		p.log.Info("Peers list is empty and / or couldn't be retrieved from server, nothing we can do, so consider the node being healthy")
-		//todo maybe we need to check if this happens too much and reboot
-		return true
-	}
-
-	apiErrorsResponsesSum := 0
-	// nodesToAsk is being reduced in every iteration, iterate until no nodes left to ask
-	for i := 0; len(nodesToAsk) > 0; i++ {
-
-		// start asking a few nodes only in first iteration to cover the case we get a healthy / unhealthy result
-		nodesBatchCount := 3
-		if i > 0 {
-			// after that ask 10% of the cluster each time to check the api problem case
-			nodesBatchCount = len(nodesToAsk) / 10
-			if nodesBatchCount == 0 {
-				nodesBatchCount = 1
-			}
-		}
-
-		chosenNodesAddresses := p.popNodes(&nodesToAsk, nodesBatchCount)
-		nrAddresses := len(chosenNodesAddresses)
-		responsesChan := make(chan poisonPill.HealthCheckResponse, nrAddresses)
-
-		for _, address := range chosenNodesAddresses {
-			go p.getHealthStatusFromPeer(address, responsesChan)
-		}
-
-		healthyResponses, unhealthyResponses, apiErrorsResponses, _ := p.sumPeersResponses(nodesBatchCount, responsesChan)
-
-		if healthyResponses > 0 {
-			p.log.Info("Peer told me I'm healthy.")
-			p.errorCount = 0
-			return true
-		}
-
-		if unhealthyResponses > 0 {
-			p.log.Info("Peer told me I'm unhealthy!")
-			return false
-		}
-
-		if apiErrorsResponses > 0 {
-			apiErrorsResponsesSum += apiErrorsResponses
-			//todo consider using [m|n]hc.spec.maxUnhealthy instead of 50%
-			if apiErrorsResponsesSum > len(p.peerList.Items)/2 { //already reached more than 50% of the nodes and all of them returned api error
-				//assuming this is a control plane failure as others can't access api-server as well
-				p.log.Info("More than 50% of the nodes couldn't access the api-server, assuming this is a control plane failure")
-				return true
-			}
-		}
-
-	}
-
-	//we asked all peers
-	p.log.Error(fmt.Errorf("failed health check"), "Failed to get health status peers. Assuming unhealthy")
-	return false
-}
-
-func (p *Peers) popNodes(nodes *[]v1.Node, count int) []string {
-	nrOfNodes := len(*nodes)
-	if nrOfNodes == 0 {
-		return []string{}
-	}
-
-	if count > nrOfNodes {
-		count = nrOfNodes
-	}
-
-	//todo maybe we should pick nodes randomly rather than relying on the order returned from api-server
-	addresses := make([]string, count)
-	for i := 0; i < count; i++ {
-		node := (*nodes)[i]
-		if len(node.Status.Addresses) == 0 || node.Status.Addresses[0].Address == "" {
-			p.log.Info("could not get address from node", "node", node.Name)
-			continue
-		}
-		addresses[i] = node.Status.Addresses[0].Address //todo node might have multiple addresses or none
-	}
-
-	*nodes = (*nodes)[count:] //remove popped nodes from the list
-
-	return addresses
-}
-
-//getHealthStatusFromPeer issues a GET request to the specified IP and returns the result from the peer into the given channel
-func (p *Peers) getHealthStatusFromPeer(endpointIp string, results chan<- poisonPill.HealthCheckResponse) {
-	url := fmt.Sprintf("%s://%s:%d/health/%s", peerProtocol, endpointIp, peerPort, p.myNodeName)
-
-	resp, err := p.httpClient.Get(url)
-	if err != nil {
-		p.log.Error(err, "failed to get health status from peer", "url", url)
-		results <- poisonPill.RequestFailed
-		return
-	}
-
-	defer func() {
-		if err = resp.Body.Close(); err != nil {
-			p.log.Error(err, "failed to close health response from peer")
-		}
-	}()
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		p.log.Error(err, "failed to read health response from peer")
-		results <- -1
-		return
-	}
-
-	healthStatusResult, err := strconv.Atoi(string(body))
-
-	if err != nil {
-		p.log.Error(err, "failed to convert health check response from string to int")
-	}
-
-	results <- poisonPill.HealthCheckResponse(healthStatusResult)
-	return
-}
-
-func (p *Peers) sumPeersResponses(nodesBatchCount int, responsesChan chan poisonPill.HealthCheckResponse) (int, int, int, int) {
-	healthyResponses := 0
-	unhealthyResponses := 0
-	apiErrorsResponses := 0
-	noResponse := 0
-
-	for i := 0; i < nodesBatchCount; i++ {
-		response := <-responsesChan
-		p.log.Info("got response from peer", "response", response)
-
-		switch response {
-		case poisonPill.Unhealthy:
-			unhealthyResponses++
-			break
-		case poisonPill.Healthy:
-			healthyResponses++
-			break
-		case poisonPill.ApiError:
-			apiErrorsResponses++
-			break
-		case poisonPill.RequestFailed:
-			noResponse++
-		default:
-			p.log.Error(fmt.Errorf("unexpected response"),
-				"Received unexpected value from peer while trying to retrieve health status", "value", response)
-		}
-	}
-
-	return healthyResponses, unhealthyResponses, apiErrorsResponses, noResponse
+	return p.peerList
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -421,6 +421,7 @@ k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apiextensions-apiserver v0.20.1
+## explicit
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1


### PR DESCRIPTION
follow up for #15 

Instead of using the peer update loop for the detecting the api server connectivity, this PR introduces an new api check loop, which polls the `readyz` endpoint of the api server. This is much cheaper than getting the full node list. So this new check can run with a short interval, while the peer update loop runs less often now.