### PR TITLE
Makefile VERSION uses git describe and tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SHELL := /bin/bash
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.1
+VERSION ?= $(shell git describe --match="v*"| sed 's/v//')
 
 # CHANNELS define the bundle channels used in the bundle. 
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")


### PR DESCRIPTION
To use it all tags from now must be annotated git tags which are meant
for releases.

Signed-off-by: Roy Golan <rgolan@redhat.com>
