### PR TITLE
Protect last seen ppr namespace and is-machine with mutex

### DIFF
--- a/controllers/poisonpillremediation_controller.go
+++ b/controllers/poisonpillremediation_controller.go
@@ -47,16 +47,19 @@ var (
 		Effect: v1.TaintEffectNoSchedule,
 	}
 
-	lastSeenPprNamespace    string
-	isLastSeenPprWasMachine bool
+	lastSeenPprNamespace  string
+	wasLastSeenPprMachine bool
 )
 
-func GetLastSeenPprNamespace() string {
+//GetLastSeenPprNamespace returns the namespace of the last reconciled PPR
+func (r *PoisonPillRemediationReconciler) GetLastSeenPprNamespace() string {
 	return lastSeenPprNamespace
 }
 
-func IsLastSeenPprWasMachine() bool {
-	return isLastSeenPprWasMachine
+//WasLastSeenPprMachine returns the a boolean indicating if the last reconcile PPR
+//was pointing an unhealthy machine or a node
+func (r *PoisonPillRemediationReconciler) WasLastSeenPprMachine() bool {
+	return wasLastSeenPprMachine
 }
 
 // PoisonPillRemediationReconciler reconciles a PoisonPillRemediation object
@@ -236,7 +239,7 @@ func (r *PoisonPillRemediationReconciler) getNodeFromPpr(ppr *v1alpha1.PoisonPil
 
 	for _, ownerRef := range ppr.OwnerReferences {
 		if ownerRef.Kind == "Machine" {
-			isLastSeenPprWasMachine = true
+			wasLastSeenPprMachine = true
 			return r.getNodeFromMachine(ownerRef, ppr.Namespace)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -104,7 +104,7 @@ func main() {
 	}
 
 	if isManager {
-		initPoisonPillManager(err, mgr)
+		initPoisonPillManager(mgr)
 	} else {
 		initPoisonPillAgent(mgr)
 	}
@@ -127,9 +127,9 @@ func main() {
 	}
 }
 
-func initPoisonPillManager(err error, mgr manager.Manager) {
+func initPoisonPillManager(mgr manager.Manager) {
 	setupLog.Info("Starting as a manager that installs the daemonset")
-	if err = (&controllers.PoisonPillConfigReconciler{
+	if err := (&controllers.PoisonPillConfigReconciler{
 		Client:            mgr.GetClient(),
 		Log:               ctrl.Log.WithName("controllers").WithName("PoisonPillConfig"),
 		Scheme:            mgr.GetScheme(),

--- a/pkg/peerassistant/health_checker.go
+++ b/pkg/peerassistant/health_checker.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	poisonPillApis "github.com/medik8s/poison-pill/api"
 	"github.com/medik8s/poison-pill/api/v1alpha1"
-	"github.com/medik8s/poison-pill/controllers"
 	corev1 "k8s.io/api/core/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,8 +51,8 @@ func init() {
 func isHealthy(nodeName string) poisonPillApis.HealthCheckResponse {
 	logger.Info("checking health for", "node", nodeName)
 
-	namespace := controllers.GetLastSeenPprNamespace()
-	isMachine := controllers.IsLastSeenPprWasMachine()
+	namespace := pprReconciler.GetLastSeenPprNamespace()
+	isMachine := pprReconciler.WasLastSeenPprMachine()
 
 	if isMachine {
 		return isHealthyMachine(nodeName, namespace)

--- a/pkg/peerassistant/rest_server.go
+++ b/pkg/peerassistant/rest_server.go
@@ -3,13 +3,12 @@ package peerassistant
 import (
 	"fmt"
 	"github.com/gorilla/mux"
+	"github.com/medik8s/poison-pill/controllers"
 	"log"
 	"net/http"
 )
 
-const (
-//port = 30001
-)
+var pprReconciler *controllers.PoisonPillRemediationReconciler
 
 func healthCheck(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
@@ -26,6 +25,7 @@ func handleRequests() {
 	log.Fatal(http.ListenAndServe(":30001", nil))
 }
 
-func Start() {
+func Start(poisonPillRemediationReconciler *controllers.PoisonPillRemediationReconciler) {
+	pprReconciler = poisonPillRemediationReconciler
 	handleRequests()
 }


### PR DESCRIPTION
there are two go routines involved here - one for the ppr reconciler and the other for the rest server.
Since they weren't protected by a mutex we had a data race.
This was introduced in 7bd2174.
In addition, made some cosmetics changes in e386c4c per @slintes comments on https://github.com/medik8s/poison-pill/pull/39 and extracted agent-init logic and manager-init logic to their own functions