### PR TITLE
Use kubectl, fallback to oc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,12 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+# Use kubectl, fallback to oc
+KUBECTL = kubectl
+ifeq (,$(shell which kubectl))
+KUBECTL=oc
+endif
+
 all: build
 
 ##@ General
@@ -114,17 +120,17 @@ docker-push: ## Push docker image with the manager.
 ##@ Deployment
 
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl apply -f -
+	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -
 
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl delete -f -
+	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete -f -
 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | envsubst | kubectl apply -f -
+	$(KUSTOMIZE) build config/default | envsubst | $(KUBECTL) apply -f -
 
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/default | kubectl delete -f -
+	$(KUSTOMIZE) build config/default | $(KUBECTL) delete -f -
 
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen


### PR DESCRIPTION
To make OpenShift e2e works without workarounds, `oc` can be used when `kubectl` is missing.

Signed-off-by: Roy Golan <rgolan@redhat.com>
