### PR TITLE
Push a container image on tag and release

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -3,6 +3,11 @@ on:
   push:
     branches:
       - master
+    tags:
+      - 'v*'
+  release:
+    types:
+      - created
 
 jobs:
   push_to_registry:
@@ -13,7 +18,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-
+        with:
+          fetch_depth: 0
+          
       - name: Log in to Quay.io
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -13,8 +13,6 @@ jobs:
   push_to_registry:
     name: Push a container image to quay.io/medik8s
     runs-on: ubuntu-20.04
-    env:
-      IMG: quay.io/medik8s/poison-pill-operator:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
This will make github to create and push a container build upon each push of a tag or a new release creation.

ECOPROJECT-148