### PR TITLE
Add e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,4 +184,5 @@ protoc-gen-go-grpc: ## Download protoc-gen-go-grpc locally if necessary.
 .PHONY: e2e-test
 e2e-test:
 	# KUBECONFIG must be set to the cluster, and PP needs to be deployed already
-	go test ./e2e -test.v -timeout 60m
+    # count arg makes the test ignoring cached test results
+	go test ./e2e -test.v -timeout 60m -count=1

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: manifests generate fmt vet ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.2/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -test.v -coverprofile cover.out
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./api/... ./controllers/... ./pkg/... -test.v -coverprofile cover.out
 
 test-mutation: verify-no-changes fetch-mutation ## Run mutation tests in manual mode.
 	echo -e "## Verifying diff ## \n##Mutations tests actually changes the code while running - this is a safeguard in order to be able to easily revert mutation tests changes (in case mutation tests have not completed properly)##"
@@ -180,3 +180,8 @@ protoc-gen-go: ## Download protoc-gen-go locally if necessary.
 PROTOC_GEN_GO_GRPC = $(shell pwd)/bin/proto/bin/protoc-gen-go-prpc
 protoc-gen-go-grpc: ## Download protoc-gen-go-grpc locally if necessary.
 	$(call go-get-tool,$(PROTOC_GEN_GO_GRPC),google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1.0)
+
+.PHONY: e2e-test
+e2e-test:
+	# KUBECONFIG must be set to the cluster, and PP needs to be deployed already
+	go test ./e2e -test.v -timeout 60m

--- a/e2e/poison_pill_test.go
+++ b/e2e/poison_pill_test.go
@@ -1,0 +1,406 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/medik8s/poison-pill/api/v1alpha1"
+	"github.com/medik8s/poison-pill/e2e/utils"
+)
+
+const (
+	disconnectCommand = "ip route add blackhole %s"
+	reconnectCommand  = "ip route delete blackhole %s"
+	nodeExecTimeout   = 20 * time.Second
+	reconnectInterval = 300 * time.Second
+)
+
+var _ = Describe("Poison Pill E2E", func() {
+
+	var node *v1.Node
+	workers := &v1.NodeList{}
+	var oldBootTime *time.Time
+	var oldUID types.UID
+	var apiIPs []string
+
+	BeforeEach(func() {
+
+		// get all things that doesn't change once only
+		if node == nil {
+			// get worker node(s)
+			selector := labels.NewSelector()
+			req, _ := labels.NewRequirement("node-role.kubernetes.io/worker", selection.Exists, []string{})
+			selector = selector.Add(*req)
+			Expect(k8sClient.List(context.Background(), workers, &client.ListOptions{LabelSelector: selector})).ToNot(HaveOccurred())
+			Expect(len(workers.Items)).To(BeNumerically(">=", 2))
+
+			node = &workers.Items[0]
+			oldUID = node.GetUID()
+
+			apiIPs = getApiIPs()
+		} else {
+			// just update the node for getting the current UID
+			Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(node), node)).ToNot(HaveOccurred())
+			oldUID = node.GetUID()
+		}
+
+		var err error
+		oldBootTime, err = getBootTime(node)
+		Expect(err).ToNot(HaveOccurred())
+
+	})
+
+	AfterEach(func() {
+		// restart pp pods for resetting logs...
+		for _, worker := range workers.Items {
+			restartPPPod(&worker)
+		}
+		// let things settle...
+		time.Sleep(30 * time.Second)
+	})
+
+	Describe("With API connectivity", func() {
+		Context("creating a PPR", func() {
+			// normal remediation
+			// - create PPR
+			// - node should reboot
+			// - node should be deleted and re-created
+
+			var ppr *v1alpha1.PoisonPillRemediation
+			BeforeEach(func() {
+				ppr = createPPR(node)
+			})
+
+			AfterEach(func() {
+				if ppr != nil {
+					_ = k8sClient.Delete(context.Background(), ppr)
+				}
+			})
+
+			It("should reboot and re-create node", func() {
+				// order matters
+				// - because the 2nd check has a small timeout only
+				checkNodeRecreate(node, oldUID)
+				checkReboot(node, oldBootTime)
+			})
+		})
+	})
+
+	Describe("Without API connectivity", func() {
+		Context("Healthy node (no PPR)", func() {
+
+			// no api connectivity
+			// a) healthy
+			//    - kill connectivity on one node
+			//    - wait until connection restored
+			//    - verify node did not reboot and wasn't deleted
+			//    - verify peer check did happen
+
+			BeforeEach(func() {
+				killApiConnection(node, apiIPs, true)
+			})
+
+			AfterEach(func() {
+				// nothing to do
+			})
+
+			It("should not reboot and not re-create node", func() {
+				// order matters
+				// - because the 2nd check has a small timeout only
+				checkNoNodeRecreate(node, oldUID)
+				checkNoReboot(node, oldBootTime)
+
+				// check logs to make sure that the actual peer health check did run
+				checkPPLogs(node, []string{"failed to check api server", "Peer told me I'm healthy."})
+			})
+		})
+
+		Context("Unhealthy node (with PPR)", func() {
+
+			// no api connectivity
+			// b) unhealthy
+			//    - kill connectivity on one node
+			//    - create PPR
+			//    - verify node does reboot and and is deleted / re-created
+
+			var ppr *v1alpha1.PoisonPillRemediation
+
+			BeforeEach(func() {
+				killApiConnection(node, apiIPs, false)
+				ppr = createPPR(node)
+			})
+
+			AfterEach(func() {
+				if ppr != nil {
+					_ = k8sClient.Delete(context.Background(), ppr)
+				}
+			})
+
+			It("should reboot and re-create node", func() {
+				// order matters
+				// - because node check works while api is disconnected from node, reboot check not
+				// - because the 2nd check has a small timeout only
+				checkNodeRecreate(node, oldUID)
+				checkReboot(node, oldBootTime)
+
+				// we can't check logs of unhealthy node anymore, check peer logs
+				peer := &workers.Items[1]
+				checkPPLogs(peer, []string{node.GetName(), "node is unhealthy"})
+			})
+
+		})
+
+		Context("Healthy node (no API connection for all)", func() {
+
+			// no api connectivity
+			// c) api issue
+			//    - kill connectivity on all nodes
+			//    - verify node does not reboot and isn't deleted
+
+			BeforeEach(func() {
+				for i, _ := range workers.Items {
+					worker := workers.Items[i]
+					go func() {
+						defer GinkgoRecover()
+						killApiConnection(&worker, apiIPs, true)
+					}()
+				}
+
+				// we can't check the boot time while it has no api connectivity, and it will not be restored by a reboot
+				// so wait until connection was restored
+				time.Sleep(time.Duration(reconnectInterval.Seconds()+10) * time.Second)
+			})
+
+			AfterEach(func() {
+				// nothing to do
+			})
+
+			It("should not reboot and not re-create node", func() {
+				// order matters
+				// - because the 2nd check has a small timeout only
+				checkNoNodeRecreate(node, oldUID)
+				checkNoReboot(node, oldBootTime)
+
+				// check logs to make sure that the actual peer health check did run
+				checkPPLogs(node, []string{"failed to check api server", "nodes couldn't access the api-server"})
+			})
+		})
+	})
+})
+
+func createPPR(node *v1.Node) *v1alpha1.PoisonPillRemediation {
+	By("creating a PPR")
+	ppr := &v1alpha1.PoisonPillRemediation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      node.GetName(),
+			Namespace: testNamespace,
+		},
+	}
+	ExpectWithOffset(1, k8sClient.Create(context.Background(), ppr)).ToNot(HaveOccurred())
+	return ppr
+}
+
+func getBootTime(node *v1.Node) (*time.Time, error) {
+	bootTimeCommand := []string{"uptime", "-s"}
+	var bootTime time.Time
+	Eventually(func() error {
+		ctx, cancel := context.WithTimeout(context.Background(), nodeExecTimeout)
+		defer cancel()
+		bootTimeString, err := utils.ExecCommandOnNode(k8sClient, bootTimeCommand, node, ctx)
+		if err != nil {
+			return err
+		}
+		bootTime, err = time.Parse("2006-01-02 15:04:05", bootTimeString)
+		if err != nil {
+			return err
+		}
+		return nil
+	}, 6*nodeExecTimeout, 10*time.Second).ShouldNot(HaveOccurred())
+	return &bootTime, nil
+}
+
+func checkNodeRecreate(node *v1.Node, oldUID types.UID) {
+	By("checking if node was recreated")
+	logger.Info("UID", "old", oldUID)
+	EventuallyWithOffset(1, func() types.UID {
+		key := client.ObjectKey{
+			Name: node.GetName(),
+		}
+		newNode := &v1.Node{}
+		if err := k8sClient.Get(context.Background(), key, newNode); err != nil {
+			logger.Error(err, "error getting node")
+			return oldUID
+		}
+		newUID := newNode.GetUID()
+		logger.Info("UID", "new", newUID)
+		return newUID
+	}, 5*time.Minute, 10*time.Second).ShouldNot(Equal(oldUID))
+}
+
+func checkReboot(node *v1.Node, oldBootTime *time.Time) {
+	By("checking reboot")
+	logger.Info("boot time", "old", oldBootTime)
+	// Note: short timeout only because this check runs after node re-create check,
+	// where already multiple minute were spent
+	EventuallyWithOffset(1, func() time.Time {
+		newBootTime, err := getBootTime(node)
+		if err != nil {
+			return time.Time{}
+		}
+		logger.Info("boot time", "new", newBootTime)
+		return *newBootTime
+	}, 2*time.Minute, 10*time.Second).Should(BeTemporally(">", *oldBootTime))
+}
+
+func killApiConnection(node *v1.Node, apiIPs []string, withReconnect bool) {
+	By("killing api connectivity")
+
+	script := composeScript(disconnectCommand, apiIPs)
+	if withReconnect {
+		script += fmt.Sprintf(" && sleep %s && ", strconv.Itoa(int(reconnectInterval.Seconds())))
+		script += composeScript(reconnectCommand, apiIPs)
+	}
+
+	command := []string{"/bin/bash", "-c", script}
+
+	var ctx context.Context
+	var cancel context.CancelFunc
+	if withReconnect {
+		ctx, cancel = context.WithTimeout(context.Background(), reconnectInterval+nodeExecTimeout)
+	} else {
+		ctx, cancel = context.WithTimeout(context.Background(), nodeExecTimeout)
+	}
+	defer cancel()
+	_, err := utils.ExecCommandOnNode(k8sClient, command, node, ctx)
+	// deadline exceeded is ok... the command does not return because of the killed connection
+	Expect(err).To(
+		Or(
+			Not(HaveOccurred()),
+			WithTransform(func(err error) string { return err.Error() },
+				ContainSubstring("deadline exceeded"),
+			),
+		),
+	)
+}
+
+func composeScript(commandTemplate string, ips []string) string {
+	script := ""
+	for i, ip := range ips {
+		if i != 0 {
+			script += " && "
+		}
+		script += fmt.Sprintf(commandTemplate, ip)
+	}
+	return script
+}
+
+func checkNoNodeRecreate(node *v1.Node, oldUID types.UID) {
+	By("checking if node was recreated")
+	logger.Info("UID", "old", oldUID)
+	// Note: short timeout because this check runs after api connection was restored,
+	// and multiple minutes were spent already on this test
+	EventuallyWithOffset(1, func() types.UID {
+		key := client.ObjectKey{
+			Name: node.GetName(),
+		}
+		newNode := &v1.Node{}
+		if err := k8sClient.Get(context.Background(), key, newNode); err != nil {
+			logger.Error(err, "error getting node")
+			return "xxx"
+		}
+		newUID := newNode.GetUID()
+		logger.Info("UID", "new", newUID)
+		return newUID
+	}, 1*time.Minute, 10*time.Second).Should(Equal(oldUID))
+}
+
+func checkNoReboot(node *v1.Node, oldBootTime *time.Time) {
+	By("checking no reboot")
+	logger.Info("boot time", "old", oldBootTime)
+	// Note: short timeout because this check runs after api connection was restored,
+	// and multiple minutes were spent already on this test
+	// we still need Eventually because getting the boot time might still fail after fiddling with api connectivity
+	EventuallyWithOffset(1, func() time.Time {
+		newBootTime, err := getBootTime(node)
+		if err != nil {
+			return time.Time{}
+		}
+		logger.Info("boot time", "new", newBootTime)
+		return *newBootTime
+	}, 1*time.Minute, 10*time.Second).Should(BeTemporally("==", *oldBootTime))
+}
+
+func checkPPLogs(node *v1.Node, expected []string) {
+	By("checking logs")
+	pod := findPPPod(node)
+	ExpectWithOffset(1, pod).ToNot(BeNil())
+
+	logs := ""
+	Eventually(func() string {
+		var err error
+		logs, err = utils.GetLogs(k8sClientSet, pod)
+		if err != nil {
+			return ""
+		}
+		return logs
+	}, 3*time.Minute, 10*time.Second).ShouldNot(BeEmpty(), "failed to get logs")
+
+	for _, exp := range expected {
+		Expect(logs).To(ContainSubstring(exp), "logs don t contain expected string, did the pod restart?")
+	}
+}
+
+func findPPPod(node *v1.Node) *v1.Pod {
+	pods := &v1.PodList{}
+	ExpectWithOffset(2, k8sClient.List(context.Background(), pods)).ToNot(HaveOccurred())
+	for _, pod := range pods.Items {
+		if strings.HasPrefix(pod.GetName(), "poison-pill-ds") && pod.Spec.NodeName == node.GetName() {
+			return &pod
+		}
+	}
+	return nil
+}
+
+func restartPPPod(node *v1.Node) {
+	By("restarting pp pod for resetting logs")
+	pod := findPPPod(node)
+	ExpectWithOffset(1, pod).ToNot(BeNil())
+	ExpectWithOffset(1, k8sClient.Delete(context.Background(), pod))
+
+	// wait for restart
+	oldPodUID := pod.GetUID()
+	EventuallyWithOffset(1, func() types.UID {
+		newPod := findPPPod(node)
+		if newPod == nil {
+			return oldPodUID
+		}
+		return newPod.GetUID()
+	}, 2*time.Minute, 10*time.Second).ShouldNot(Equal(oldPodUID))
+}
+
+func getApiIPs() []string {
+	key := client.ObjectKey{
+		Namespace: "default",
+		Name:      "kubernetes",
+	}
+	ep := &v1.Endpoints{}
+	ExpectWithOffset(1, k8sClient.Get(context.Background(), key, ep)).ToNot(HaveOccurred())
+	ips := make([]string, 0)
+	for _, addr := range ep.Subsets[0].Addresses {
+		ips = append(ips, addr.IP)
+	}
+	return ips
+}

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -1,0 +1,61 @@
+package e2e
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/medik8s/poison-pill/api/v1alpha1"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+// needs to match CI config!
+const testNamespace = "poison-pill"
+
+var cfg *rest.Config
+var k8sClient client.Client
+var k8sClientSet *kubernetes.Clientset
+var logger *logf.DelegatingLogger
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"E2E Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func(done Done) {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	logger = logf.Log
+
+	err := v1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	cfg, err = config.GetConfig()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).ToNot(BeNil())
+
+	k8sClientSet, err = kubernetes.NewForConfig(cfg)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClientSet).ToNot(BeNil())
+
+	close(done)
+
+}, 60)

--- a/e2e/utils/node.go
+++ b/e2e/utils/node.go
@@ -1,0 +1,107 @@
+package utils
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// this code is mostly from https://github.com/openshift-kni/performance-addon-operators/tree/master/functests/utils
+// it uses the MachineConfigDaemon pods for running commands on a node
+// so we don't need to create a new pod for this
+
+const (
+	// namespaceMachineConfigOperator contains the namespace of the machine-config-opereator
+	namespaceMachineConfigOperator = "openshift-machine-config-operator"
+	// containerMachineConfigDaemon contains the name of the machine-config-daemon container
+	containerMachineConfigDaemon = "machine-config-daemon"
+)
+
+var logger *logf.DelegatingLogger
+
+func init() {
+	logger = logf.Log
+}
+
+// ExecCommandOnNode executes given command on given node and returns the result
+func ExecCommandOnNode(c client.Client, cmd []string, node *corev1.Node, ctx context.Context) (string, error) {
+	out, err := execCommandOnMachineConfigDaemon(c, node, cmd, ctx)
+	if err != nil {
+		return "", err
+	}
+	return strings.Trim(string(out), "\n"), nil
+}
+
+// execCommandOnMachineConfigDaemon returns the output of the command execution on the machine-config-daemon pod that runs on the specified node
+func execCommandOnMachineConfigDaemon(c client.Client, node *corev1.Node, command []string, ctx context.Context) ([]byte, error) {
+	mcd, err := getMachineConfigDaemonByNode(c, node)
+	if err != nil {
+		return nil, err
+	}
+	logger.Info("found mcd for node\n", "mcd name", mcd.Name, "node name", node.Name)
+
+	initialArgs := []string{
+		"exec",
+		"-i",
+		"-n", namespaceMachineConfigOperator,
+		"-c", containerMachineConfigDaemon,
+		"--request-timeout", "600",
+		mcd.Name,
+		"--",
+	}
+	initialArgs = append(initialArgs, command...)
+	return execAndLogCommand(ctx, "oc", initialArgs...)
+}
+
+// getMachineConfigDaemonByNode returns the machine-config-daemon pod that runs on the specified node
+func getMachineConfigDaemonByNode(c client.Client, node *corev1.Node) (*corev1.Pod, error) {
+
+	listOptions := &client.ListOptions{
+		Namespace:     namespaceMachineConfigOperator,
+		FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": node.Name}),
+		LabelSelector: labels.SelectorFromSet(labels.Set{"k8s-app": "machine-config-daemon"}),
+	}
+
+	mcds := &corev1.PodList{}
+	if err := c.List(context.Background(), mcds, listOptions); err != nil {
+		return nil, err
+	}
+
+	if len(mcds.Items) < 1 {
+		return nil, fmt.Errorf("failed to get machine-config-daemon pod for the node %q", node.Name)
+	}
+	return &mcds.Items[0], nil
+}
+
+func execAndLogCommand(ctx context.Context, name string, arg ...string) ([]byte, error) {
+	outData, _, err := execAndLogCommandWithStderr(ctx, name, arg...)
+	return outData, err
+}
+
+func execAndLogCommandWithStderr(ctx context.Context, name string, arg ...string) ([]byte, []byte, error) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, name, arg...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	outData := stdout.Bytes()
+	errData := stderr.Bytes()
+
+	logger.Info("run command\n", "command", name, "args", arg, "error", err, "stdout", string(outData), "stderr", string(errData))
+
+	// We want to check the context error to see if the timeout was executed.
+	if ctx.Err() == context.DeadlineExceeded {
+		return nil, nil, fmt.Errorf("deadline exceeded")
+	}
+	return outData, errData, err
+}

--- a/e2e/utils/pod.go
+++ b/e2e/utils/pod.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"bytes"
+	"context"
+	"io"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// GetLogs returns logs of the specified pod
+func GetLogs(c *kubernetes.Clientset, pod *corev1.Pod) (string, error) {
+	logStream, err := c.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{}).Stream(context.Background())
+	if err != nil {
+		return "", err
+	}
+	defer logStream.Close()
+
+	buf := new(bytes.Buffer)
+	if _, err := io.Copy(buf, logStream); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}

--- a/pkg/apicheck/check.go
+++ b/pkg/apicheck/check.go
@@ -23,7 +23,6 @@ import (
 	"github.com/medik8s/poison-pill/pkg/reboot"
 )
 
-
 type ApiConnectivityCheck struct {
 	client.Reader
 	config      *ApiConnectivityCheckConfig

--- a/pkg/peerhealth/server.go
+++ b/pkg/peerhealth/server.go
@@ -134,7 +134,7 @@ func (s Server) IsHealthy(ctx context.Context, request *HealthRequest) (*HealthR
 			s.log.Info("no PPR seen yet, and API server issue, returning API error", "api error", err)
 			return toResponse(poisonPillApis.ApiError)
 		}
-		s.log.Info("no PPR seen yet, assuming healthy")
+		s.log.Info("no PPR seen yet, node is healthy")
 		return toResponse(poisonPillApis.Healthy)
 	}
 
@@ -179,14 +179,14 @@ func (s Server) isHealthyByPpr(ctx context.Context, pprName string, pprNamespace
 	_, err := s.client.Resource(pprRes).Namespace(pprNamespace).Get(apiCtx, pprName, metav1.GetOptions{})
 	if err != nil {
 		if apiErrors.IsNotFound(err) {
-			s.log.Info("healthy")
+			s.log.Info("node is healthy")
 			return poisonPillApis.Healthy
 		}
 		s.log.Error(err, "api error")
 		return poisonPillApis.ApiError
 	}
 
-	s.log.Info("unhealthy")
+	s.log.Info("node is unhealthy")
 	return poisonPillApis.Unhealthy
 }
 


### PR DESCRIPTION
This PR adds some e2e tests. They can be run with `make e2e-test` and need cluster with a valid KUBECONFIG and Poison Pill already deployed.
The tests are a bit flaky still... especially the last one (api issue on all nodes). Sometimes the node reboots (which is unexpected), and sometimes the pod restarts, which makes it impossible to find expected logs. However, ideally, it looks like this:

```
$ make e2e-test
# KUBECONFIG must be set to the cluster, and PP needs to be deployed already
go test ./e2e -test.v -timeout 60m
=== RUN   TestE2E
Running Suite: E2E Suite
========================
Random Seed: 1625510853
Will run 4 of 4 specs

I0705 20:47:35.653951 1685765 request.go:655] Throttling request took 1.048711117s, request: GET:https://api.ostest.bm1.local:6443/apis/coordination.k8s.io/v1beta1?timeout=32s
• [SLOW TEST:305.730 seconds]
Poison Pill E2E
/home/msluiter/dev/work/medik8s/poison-pill/e2e/poison_pill_test.go:31
  With API connectivity
  /home/msluiter/dev/work/medik8s/poison-pill/e2e/poison_pill_test.go:75
    creating a PPR
    /home/msluiter/dev/work/medik8s/poison-pill/e2e/poison_pill_test.go:76
      should reboot and re-create node
      /home/msluiter/dev/work/medik8s/poison-pill/e2e/poison_pill_test.go:93
------------------------------
• [SLOW TEST:404.176 seconds]
Poison Pill E2E
/home/msluiter/dev/work/medik8s/poison-pill/e2e/poison_pill_test.go:31
  Without API connectivity
  /home/msluiter/dev/work/medik8s/poison-pill/e2e/poison_pill_test.go:102
    Healthy node (no PPR)
    /home/msluiter/dev/work/medik8s/poison-pill/e2e/poison_pill_test.go:103
      should not reboot and not re-create node
      /home/msluiter/dev/work/medik8s/poison-pill/e2e/poison_pill_test.go:120
------------------------------
• [SLOW TEST:358.839 seconds]
Poison Pill E2E
/home/msluiter/dev/work/medik8s/poison-pill/e2e/poison_pill_test.go:31
  Without API connectivity
  /home/msluiter/dev/work/medik8s/poison-pill/e2e/poison_pill_test.go:102
    Unhealthy node (with PPR)
    /home/msluiter/dev/work/medik8s/poison-pill/e2e/poison_pill_test.go:131
      should reboot and re-create node
      /home/msluiter/dev/work/medik8s/poison-pill/e2e/poison_pill_test.go:152
------------------------------
• [SLOW TEST:375.402 seconds]
Poison Pill E2E
/home/msluiter/dev/work/medik8s/poison-pill/e2e/poison_pill_test.go:31
  Without API connectivity
  /home/msluiter/dev/work/medik8s/poison-pill/e2e/poison_pill_test.go:102
    Healthy node (no API connection for all)
    /home/msluiter/dev/work/medik8s/poison-pill/e2e/poison_pill_test.go:166
      should not reboot and not re-create node
      /home/msluiter/dev/work/medik8s/poison-pill/e2e/poison_pill_test.go:191
------------------------------


Ran 4 of 4 Specs in 1453.855 seconds
SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestE2E (1453.86s)
PASS
ok      github.com/medik8s/poison-pill/e2e      1453.889s
```
OpenshiftCI will be extended with this as soon as this is merged.