### PR TITLE
Re-create config CR if it was deleted 

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -12,11 +12,18 @@ rules:
   - daemonsets
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
   - update
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets/finalizers
+  verbs:
+  - update
 - apiGroups:
   - ""
   resources:

--- a/main.go
+++ b/main.go
@@ -136,6 +136,7 @@ func initPoisonPillManager(mgr manager.Manager) {
 		Log:               ctrl.Log.WithName("controllers").WithName("PoisonPillConfig"),
 		Scheme:            mgr.GetScheme(),
 		InstallFileFolder: "./install",
+		DefaultPpcCreator: newConfigIfNotExist,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PoisonPillConfig")
 		os.Exit(1)


### PR DESCRIPTION
Re-create config CR if it was deleted and add RBAC to delete DS and update finalizer to resolve an error in the log - 'cannot set an ownerRef on a resource you can't delete'
