### PR TITLE
Avoid remediation loops by not restoring node's status.

### DIFF
--- a/controllers/poisonpillremediation_controller.go
+++ b/controllers/poisonpillremediation_controller.go
@@ -333,9 +333,7 @@ func (r *PoisonPillRemediationReconciler) restoreNode(nodeToRestore *v1.Node) (c
 	nodeToRestore.Spec.Taints = taints
 	nodeToRestore.Spec.Unschedulable = false
 	nodeToRestore.CreationTimestamp = metav1.Now()
-
-	//todo should we also delete conditions that made the node reach the unhealthy state?
-	//I'm afraid we might cause remediation loops
+	nodeToRestore.Status = v1.NodeStatus{}
 
 	if err := r.Client.Create(context.TODO(), nodeToRestore); err != nil {
 		if apiErrors.IsAlreadyExists(err) {


### PR DESCRIPTION
The node's status should be set by the node itself. Otherwise, we restore the node conditions that created the unhealthy state which might lead to remediation loop
