### PR TITLE
Prevent potential peer list mutation

### DIFF
--- a/pkg/peers/peers.go
+++ b/pkg/peers/peers.go
@@ -102,9 +102,9 @@ func (p *Peers) updatePeers(ctx context.Context) {
 	p.peerList = nodes
 }
 
-func (p *Peers) GetPeers() v1.NodeList {
+func (p *Peers) GetPeers() *v1.NodeList {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
-	return p.peerList
+	return p.peerList.DeepCopy()
 }

--- a/pkg/peers/peers.go
+++ b/pkg/peers/peers.go
@@ -24,7 +24,7 @@ const (
 type Peers struct {
 	client.Reader
 	log                logr.Logger
-	peerList           *v1.NodeList
+	peerList           v1.NodeList
 	peerSelector       labels.Selector
 	peerUpdateInterval time.Duration
 	myNodeName         string
@@ -36,7 +36,7 @@ func New(myNodeName string, peerUpdateInterval time.Duration, reader client.Read
 	return &Peers{
 		Reader:             reader,
 		log:                log,
-		peerList:           &v1.NodeList{},
+		peerList:           v1.NodeList{},
 		peerUpdateInterval: peerUpdateInterval,
 		myNodeName:         myNodeName,
 		mutex:              sync.Mutex{},
@@ -88,12 +88,12 @@ func (p *Peers) updatePeers(ctx context.Context) {
 	readerCtx, cancel := context.WithTimeout(ctx, p.apiServerTimeout)
 	defer cancel()
 
-	nodes := &v1.NodeList{}
+	nodes := v1.NodeList{}
 	// get some nodes, but not ourself
-	if err := p.List(readerCtx, nodes, client.MatchingLabelsSelector{Selector: p.peerSelector}); err != nil {
+	if err := p.List(readerCtx, &nodes, client.MatchingLabelsSelector{Selector: p.peerSelector}); err != nil {
 		if errors.IsNotFound(err) {
 			// we are the only node at the moment... reset peerList
-			p.peerList = &v1.NodeList{}
+			p.peerList = v1.NodeList{}
 		}
 		p.log.Error(err, "failed to update peer list")
 		return
@@ -102,7 +102,7 @@ func (p *Peers) updatePeers(ctx context.Context) {
 	p.peerList = nodes
 }
 
-func (p *Peers) GetPeers() *v1.NodeList {
+func (p *Peers) GetPeers() v1.NodeList {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 


### PR DESCRIPTION
Use a copy of a peer list instead of a reference to prevent mutation
of that list outside of the inner lock. Without this the lock
taked inside any guarded block is just useless because the list
reference just leaks out.

Signed-off-by: Roy Golan <rgolan@redhat.com>
