### PR TITLE
reduce cpu requirement from 100m to 20m

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,9 +6,9 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=poison-pill
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.4.0+git
-LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1

--- a/bundle/manifests/poison-pill.clusterserviceversion.yaml
+++ b/bundle/manifests/poison-pill.clusterserviceversion.yaml
@@ -268,7 +268,7 @@ spec:
                     cpu: 100m
                     memory: 100Mi
                   requests:
-                    cpu: 100m
+                    cpu: 20m
                     memory: 50Mi
                 securityContext:
                   allowPrivilegeEscalation: false

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,9 +5,9 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: poison-pill
   operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.4.0+git
-  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -55,7 +55,7 @@ spec:
             cpu: 100m
             memory: 100Mi
           requests:
-            cpu: 100m
+            cpu: 20m
             memory: 50Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/install/poison-pill-deamonset.yaml
+++ b/install/poison-pill-deamonset.yaml
@@ -49,7 +49,7 @@ spec:
           protocol: TCP
         resources:
           requests:
-            cpu: 100m
+            cpu: 20m
             memory: 50Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File


### PR DESCRIPTION
reduce cpu requirement to be able to run in lower footprint.
we encountered some problems where the scheduler won't schedule the pod due to low memory (on testing clusters)