### PR TITLE
Reconcile only the default config CR

### DIFF
--- a/api/v1alpha1/poisonpillconfig_types.go
+++ b/api/v1alpha1/poisonpillconfig_types.go
@@ -24,7 +24,7 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 const (
-	configCRName                          = "poison-pill-config"
+	ConfigCRName                          = "poison-pill-config"
 	templateCRName                        = "poison-pill-default-template"
 	defaultWatchdogPath                   = "/dev/watchdog1"
 	defaultSafetToAssumeNodeRebootTimeout = 180
@@ -82,7 +82,7 @@ func init() {
 
 func NewDefaultPoisonPillConfig() PoisonPillConfig {
 	return PoisonPillConfig{
-		ObjectMeta: metav1.ObjectMeta{Name: configCRName},
+		ObjectMeta: metav1.ObjectMeta{Name: ConfigCRName},
 		Spec: PoisonPillConfigSpec{
 			WatchdogFilePath:                    defaultWatchdogPath,
 			SafeTimeToAssumeNodeRebootedSeconds: defaultSafetToAssumeNodeRebootTimeout,

--- a/controllers/poisonpillconfig_controller.go
+++ b/controllers/poisonpillconfig_controller.go
@@ -44,6 +44,7 @@ type PoisonPillConfigReconciler struct {
 	Scheme            *runtime.Scheme
 	InstallFileFolder string
 	DefaultPpcCreator func(c client.Client) error
+	Namespace         string
 }
 
 //+kubebuilder:rbac:groups=poison-pill.medik8s.io,resources=poisonpillconfigs,verbs=get;list;watch;create;update;patch;delete
@@ -57,6 +58,12 @@ type PoisonPillConfigReconciler struct {
 
 func (r *PoisonPillConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("poisonpillconfig", req.NamespacedName)
+
+	if req.Name != poisonpillv1alpha1.ConfigCRName || req.Namespace != r.Namespace {
+		logger.Info(fmt.Sprintf("ignoring poisonpillconfig CRs that are not named '%s' or not in the namespace of the operator: '%s'",
+			poisonpillv1alpha1.ConfigCRName, r.Namespace))
+		return ctrl.Result{}, nil
+	}
 
 	config := &poisonpillv1alpha1.PoisonPillConfig{}
 	if err := r.Client.Get(context.Background(), req.NamespacedName, config); err != nil {

--- a/controllers/poisonpillconfig_controller_test.go
+++ b/controllers/poisonpillconfig_controller_test.go
@@ -18,12 +18,11 @@ import (
 )
 
 var _ = Describe("ppc controller Test", func() {
+	dsName := "poison-pill-ds"
 
 	Context("DS installation", func() {
 		dummyPoisonPillImage := "poison-pill-image"
 		os.Setenv("POISON_PILL_IMAGE", dummyPoisonPillImage)
-
-		dsName := "poison-pill-ds"
 
 		nsToCreate := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -110,6 +109,40 @@ var _ = Describe("ppc controller Test", func() {
 
 			Expect(createdConfig.Spec.WatchdogFilePath).To(Equal("/dev/watchdog1"))
 			Expect(createdConfig.Spec.SafeTimeToAssumeNodeRebootedSeconds).To(Equal(180))
+		})
+	})
+
+	Context("Wrong poison pill config CR", func() {
+		var dsResourceVersion string
+		ds := &appsv1.DaemonSet{}
+		key := types.NamespacedName{
+			Namespace: namespace,
+			Name:      dsName,
+		}
+
+		It("get DS resource version", func() {
+			Expect(k8sClient.Get(context.Background(), key, ds)).To(Succeed())
+			dsResourceVersion = ds.ResourceVersion
+		})
+
+		config := &poisonpillv1alpha1.PoisonPillConfig{}
+		config.Kind = "PoisonPillConfig"
+		config.APIVersion = "poison-pill.medik8s.io/v1alpha1"
+		config.Name = "not-the-expected-name"
+		config.Spec.WatchdogFilePath = "foo"
+		config.Spec.SafeTimeToAssumeNodeRebootedSeconds = 9999
+		config.Namespace = namespace
+
+		It("Create config CR", func() {
+			Expect(k8sClient).To(Not(BeNil()))
+			Expect(k8sClient.Create(context.Background(), config)).To(Succeed())
+		})
+
+		It("Daemonset should not be changed", func() {
+			Consistently(func() string {
+				Expect(k8sClient.Get(context.Background(), key, ds)).To(Succeed())
+				return ds.ResourceVersion
+			}, 20*time.Second, 1*time.Second).Should(Equal(dsResourceVersion))
 		})
 	})
 

--- a/controllers/poisonpillconfig_controller_test.go
+++ b/controllers/poisonpillconfig_controller_test.go
@@ -114,27 +114,28 @@ var _ = Describe("ppc controller Test", func() {
 
 	Context("Wrong poison pill config CR", func() {
 		var dsResourceVersion string
-		ds := &appsv1.DaemonSet{}
-		key := types.NamespacedName{
-			Namespace: namespace,
-			Name:      dsName,
-		}
+		var key types.NamespacedName
+		var ds *appsv1.DaemonSet
+		BeforeEach(func() {
+			ds = &appsv1.DaemonSet{}
+			key = types.NamespacedName{
+				Namespace: namespace,
+				Name:      dsName,
+			}
 
-		It("get DS resource version", func() {
+			By("get DS resource version")
 			Expect(k8sClient.Get(context.Background(), key, ds)).To(Succeed())
 			dsResourceVersion = ds.ResourceVersion
-		})
 
-		config := &poisonpillv1alpha1.PoisonPillConfig{}
-		config.Kind = "PoisonPillConfig"
-		config.APIVersion = "poison-pill.medik8s.io/v1alpha1"
-		config.Name = "not-the-expected-name"
-		config.Spec.WatchdogFilePath = "foo"
-		config.Spec.SafeTimeToAssumeNodeRebootedSeconds = 9999
-		config.Namespace = namespace
+			By("create a config CR")
+			config := &poisonpillv1alpha1.PoisonPillConfig{}
+			config.Kind = "PoisonPillConfig"
+			config.APIVersion = "poison-pill.medik8s.io/v1alpha1"
+			config.Name = "not-the-expected-name"
+			config.Spec.WatchdogFilePath = "foo"
+			config.Spec.SafeTimeToAssumeNodeRebootedSeconds = 9999
+			config.Namespace = namespace
 
-		It("Create config CR", func() {
-			Expect(k8sClient).To(Not(BeNil()))
 			Expect(k8sClient.Create(context.Background(), config)).To(Succeed())
 		})
 

--- a/controllers/poisonpillconfig_controller_test.go
+++ b/controllers/poisonpillconfig_controller_test.go
@@ -41,7 +41,7 @@ var _ = Describe("ppc controller Test", func() {
 		config.APIVersion = "poison-pill.medik8s.io/v1alpha1"
 		config.Spec.WatchdogFilePath = "/dev/foo"
 		config.Spec.SafeTimeToAssumeNodeRebootedSeconds = 123
-		config.Name = "config-sample"
+		config.Name = poisonpillv1alpha1.ConfigCRName
 		config.Namespace = namespace
 
 		It("Config CR should be created", func() {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -131,6 +131,7 @@ var _ = BeforeSuite(func() {
 		Log:               ctrl.Log.WithName("controllers").WithName("poison-pill-config-controller"),
 		InstallFileFolder: "../install/",
 		Scheme:            scheme.Scheme,
+		Namespace:         namespace,
 	}).SetupWithManager(k8sManager)
 
 	// peers need their own node on start

--- a/main.go
+++ b/main.go
@@ -131,12 +131,19 @@ func main() {
 
 func initPoisonPillManager(mgr manager.Manager) {
 	setupLog.Info("Starting as a manager that installs the daemonset")
+	ns, err := getDeploymentNamespace()
+	if err != nil {
+		setupLog.Error(err, "failed to get deployed namespace from env var")
+		os.Exit(1)
+	}
+
 	if err := (&controllers.PoisonPillConfigReconciler{
 		Client:            mgr.GetClient(),
 		Log:               ctrl.Log.WithName("controllers").WithName("PoisonPillConfig"),
 		Scheme:            mgr.GetScheme(),
 		InstallFileFolder: "./install",
 		DefaultPpcCreator: newConfigIfNotExist,
+		Namespace:         ns,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PoisonPillConfig")
 		os.Exit(1)


### PR DESCRIPTION
We expect only one poison pill config CR, but we don't enforce this.
This commit ignores ppc that are not in the namespace of the operator or not in the default config name, which practically means it reconciles only one CR.
