### PR TITLE
Increase memory allocation

### DIFF
--- a/bundle/manifests/poison-pill.clusterserviceversion.yaml
+++ b/bundle/manifests/poison-pill.clusterserviceversion.yaml
@@ -290,12 +290,9 @@ spec:
                   initialDelaySeconds: 5
                   periodSeconds: 10
                 resources:
-                  limits:
-                    cpu: 100m
-                    memory: 100Mi
                   requests:
                     cpu: 20m
-                    memory: 50Mi
+                    memory: 110Mi
                 securityContext:
                   allowPrivilegeEscalation: false
               securityContext:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -51,11 +51,8 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
-          limits:
-            cpu: 100m
-            memory: 100Mi
           requests:
             cpu: 20m
-            memory: 50Mi
+            memory: 110Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/install/poison-pill-deamonset.yaml
+++ b/install/poison-pill-deamonset.yaml
@@ -50,7 +50,7 @@ spec:
         resources:
           requests:
             cpu: 20m
-            memory: 50Mi
+            memory: 60Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       dnsPolicy: ClusterFirst


### PR DESCRIPTION
When installing on a physical cluster, we saw the the poison pill controller (not the DS) was killed due to OOM.
In other cluster, we saw the usage was close to 100M, so the mem request was increased and limits were removed per OCP best practices.

DS memory also increased a little bit per the observed mem usage in some cluster.
