### PR TITLE
Run remediation only for nodes who have the poison pill pod

### DIFF
--- a/bundle/manifests/poison-pill.clusterserviceversion.yaml
+++ b/bundle/manifests/poison-pill.clusterserviceversion.yaml
@@ -104,6 +104,13 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - pods
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - ""
+          resources:
           - secrets
           verbs:
           - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -39,6 +39,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create

--- a/controllers/controller_test.go
+++ b/controllers/controller_test.go
@@ -2,19 +2,19 @@ package controllers_test
 
 import (
 	"context"
-	"github.com/medik8s/poison-pill/controllers"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/medik8s/poison-pill/controllers"
 	poisonpillv1alpha1 "github.com/medik8s/poison-pill/api/v1alpha1"
 )
 

--- a/controllers/controller_test.go
+++ b/controllers/controller_test.go
@@ -3,6 +3,8 @@ package controllers_test
 import (
 	"context"
 	"github.com/medik8s/poison-pill/controllers"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -35,6 +37,40 @@ var _ = Describe("ppr Controller", func() {
 
 	ppr := &poisonpillv1alpha1.PoisonPillRemediation{}
 
+	Context("Unhealthy node without poison-pill pod", func() {
+		//if the unhealthy node doesn't have the poison-pill pod
+		//we don't want to delete the node, since it might never
+		//be in a safe state (i.e. rebooted)
+
+		BeforeEach(func() {
+			ppr := &poisonpillv1alpha1.PoisonPillRemediation{}
+			ppr.Name = unhealthyNodeName
+			ppr.Namespace = pprNamespace
+
+			Expect(k8sClient.Create(context.TODO(), ppr)).To(Succeed(), "failed to create ppr CR")
+		})
+
+		AfterEach(func() {
+			Expect(k8sClient.Delete(context.Background(), ppr)).To(Succeed(), "failed to delete ppr CR")
+		})
+
+		It("ppr should not have finalizers", func() {
+			pprKey := client.ObjectKey{
+				Namespace: pprNamespace,
+				Name:      unhealthyNodeName,
+			}
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), pprKey, ppr)
+			}, 10*time.Second, 200*time.Millisecond).Should(Succeed())
+
+			Consistently(func() []string {
+				Expect(k8sClient.Get(context.Background(), pprKey, ppr)).To(Succeed())
+				//if no finalizer was set, it means we didn't start remediation process
+				return ppr.Finalizers
+			}, 10*time.Second, 250*time.Millisecond).Should(BeEmpty())
+		})
+	})
+
 	Context("Unhealthy node with api-server access", func() {
 
 		It("Disable api-server failure", func() {
@@ -59,9 +95,41 @@ var _ = Describe("ppr Controller", func() {
 			Expect(node.CreationTimestamp).ToNot(BeZero())
 		})
 
+		Context("simulate daemonset pods assigned to nodes", func() {
+			//since we don't have a scheduler in test, we need to do its work and create pp pod for that node
+			BeforeEach(func() {
+				pod := &v1.Pod{}
+				pod.Spec.NodeName = unhealthyNodeName
+				pod.Labels = map[string]string{"app": "poison-pill-agent"}
+				pod.Name = "poison-pill"
+				pod.Namespace = namespace
+				container := v1.Container{
+					Name:  "foo",
+					Image: "foo",
+				}
+				pod.Spec.Containers = []v1.Container{container}
+				Expect(k8sClient.Create(context.Background(), pod)).To(Succeed())
+			})
+
+			It("poison pill agent pod should exist", func() {
+				podList := &v1.PodList{}
+
+				selector := labels.NewSelector()
+				requirement, _ := labels.NewRequirement("app", selection.Equals, []string{"poison-pill-agent"})
+				selector = selector.Add(*requirement)
+
+				Eventually(func() int {
+					Expect(k8sClient.List(context.Background(), podList, &client.ListOptions{LabelSelector: selector})).To(Succeed())
+					return len(podList.Items)
+				}, 5*time.Second, 250*time.Millisecond).Should(Equal(1))
+
+			})
+		})
+
 		beforePPR := time.Now()
 
 		It("Create ppr for unhealthy node", func() {
+			ppr = &poisonpillv1alpha1.PoisonPillRemediation{}
 			ppr.Name = unhealthyNodeName
 			ppr.Namespace = pprNamespace
 			Expect(k8sClient.Create(context.TODO(), ppr)).To(Succeed(), "failed to create ppr CR")

--- a/controllers/poisonpillconfig_controller_test.go
+++ b/controllers/poisonpillconfig_controller_test.go
@@ -10,7 +10,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -23,17 +22,6 @@ var _ = Describe("ppc controller Test", func() {
 	Context("DS installation", func() {
 		dummyPoisonPillImage := "poison-pill-image"
 		os.Setenv("POISON_PILL_IMAGE", dummyPoisonPillImage)
-
-		nsToCreate := &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: namespace,
-			},
-		}
-
-		It("Create poison-pill namespace", func() {
-			Expect(k8sClient).To(Not(BeNil()))
-			Expect(k8sClient.Create(context.Background(), nsToCreate)).To(Succeed())
-		})
 
 		config := &poisonpillv1alpha1.PoisonPillConfig{}
 		config.Kind = "PoisonPillConfig"

--- a/controllers/poisonpillremediation_controller.go
+++ b/controllers/poisonpillremediation_controller.go
@@ -19,6 +19,8 @@ package controllers
 import (
 	"context"
 	"errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"sync"
 	"time"
 
@@ -172,6 +174,18 @@ func (r *PoisonPillRemediationReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, nil
 	}
 
+	hasPoisonPillPod, err := r.hasPoisonPillAgentPod(node)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	//if the unhealthy node doesn't have the poison pill agent pod, the node might not reboot, and we might end up
+	//in deleting a running node
+	if !hasPoisonPillPod {
+		r.logger.Error(errors.New("node is missing poison pill agent pod, which means the node might not reboot when we'll delete the node. Skipping remediation"), "")
+		return ctrl.Result{}, nil
+	}
+
 	if !controllerutil.ContainsFinalizer(ppr, PPRFinalizer) {
 		if !ppr.DeletionTimestamp.IsZero() {
 			//ppr is going to be deleted before we started any remediation action, so taking no-op
@@ -238,6 +252,27 @@ func (r *PoisonPillRemediationReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+}
+
+func (r *PoisonPillRemediationReconciler) hasPoisonPillAgentPod(node *v1.Node) (bool, error) {
+	podList := &v1.PodList{}
+
+	selector := labels.NewSelector()
+	requirement, _ := labels.NewRequirement("app", selection.Equals, []string{"poison-pill-agent"})
+	selector = selector.Add(*requirement)
+
+	err := r.Client.List(context.Background(), podList, &client.ListOptions{LabelSelector: selector})
+	if err != nil {
+		r.logger.Error(err, "failed to list poison pill agent pods")
+		return false, err
+	}
+
+	for _, pod := range podList.Items {
+		if pod.Spec.NodeName == node.Name {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 //returns the lastHeartbeatTime of the first condition, if exists. Otherwise returns the zero value

--- a/controllers/poisonpillremediation_controller.go
+++ b/controllers/poisonpillremediation_controller.go
@@ -91,6 +91,7 @@ func (r *PoisonPillRemediationReconciler) SetupWithManager(mgr ctrl.Manager) err
 		Complete(r)
 }
 
+//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list
 //+kubebuilder:rbac:groups=poison-pill.medik8s.io,resources=poisonpillremediationtemplates,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=poison-pill.medik8s.io,resources=poisonpillremediationtemplates/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=poison-pill.medik8s.io,resources=poisonpillremediationtemplates/finalizers,verbs=update

--- a/controllers/poisonpillremediation_controller.go
+++ b/controllers/poisonpillremediation_controller.go
@@ -19,8 +19,6 @@ package controllers
 import (
 	"context"
 	"errors"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	"sync"
 	"time"
 
@@ -34,6 +32,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 
 	"github.com/medik8s/poison-pill/api/v1alpha1"
 	"github.com/medik8s/poison-pill/pkg/reboot"

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -19,6 +19,7 @@ package controllers_test
 import (
 	"context"
 	"errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"path/filepath"
 	"testing"
@@ -125,6 +126,14 @@ var _ = BeforeSuite(func() {
 		false,
 	}
 	Expect(k8sClient).ToNot(BeNil())
+
+	nsToCreate := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
+	}
+
+	Expect(k8sClient.Create(context.Background(), nsToCreate)).To(Succeed())
 
 	err = (&controllers.PoisonPillConfigReconciler{
 		Client:            k8sManager.GetClient(),

--- a/install/poison-pill-deamonset.yaml
+++ b/install/poison-pill-deamonset.yaml
@@ -14,6 +14,7 @@ spec:
       creationTimestamp: null
       labels:
         control-plane: controller-manager
+        app: poison-pill-agent
     spec:
       serviceAccountName: poison-pill-controller-manager
       priorityClassName: system-node-critical


### PR DESCRIPTION
if the unhealthy node doesn't have the poison-pill pod we don't want to delete the node, since it might never be in a safe state (i.e. rebooted)
