### PR TITLE
Verify the poison pill pod is running before remediation

### DIFF
--- a/controllers/controller_test.go
+++ b/controllers/controller_test.go
@@ -7,15 +7,15 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/medik8s/poison-pill/controllers"
 	poisonpillv1alpha1 "github.com/medik8s/poison-pill/api/v1alpha1"
+	"github.com/medik8s/poison-pill/controllers"
 )
 
 const (
@@ -109,6 +109,9 @@ var _ = Describe("ppr Controller", func() {
 				}
 				pod.Spec.Containers = []v1.Container{container}
 				Expect(k8sClient.Create(context.Background(), pod)).To(Succeed())
+
+				pod.Status.Phase = v1.PodRunning
+				Expect(k8sClient.Status().Update(context.Background(), pod)).To(Succeed())
 			})
 
 			It("poison pill agent pod should exist", func() {


### PR DESCRIPTION
Currently, we remediate only nodes who have the poison pill pod, but we don't check if the pod is running.
It could be the pod will be in non-running state, e.g. OOMKilled etc.
This commit makes sure the pod on the unhealthy node is in running state.
