### PR TITLE
Enable softdog in case the user provided watchdog doesn't exist

### DIFF
--- a/api/v1alpha1/poisonpillconfig_types.go
+++ b/api/v1alpha1/poisonpillconfig_types.go
@@ -26,7 +26,7 @@ import (
 const (
 	ConfigCRName                          = "poison-pill-config"
 	templateCRName                        = "poison-pill-default-template"
-	defaultWatchdogPath                   = "/dev/watchdog1"
+	defaultWatchdogPath                   = "/dev/watchdog"
 	defaultSafetToAssumeNodeRebootTimeout = 180
 )
 
@@ -36,7 +36,7 @@ type PoisonPillConfigSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// WatchdogFilePath is the watchdog file path that should be available on each node, e.g. /dev/watchdog
-	// +kubebuilder:default=/dev/watchdog1
+	// +kubebuilder:default=/dev/watchdog
 	WatchdogFilePath string `json:"watchdogFilePath,omitempty"`
 
 	// SafeTimeToAssumeNodeRebootedSeconds is the time after which the healthy poison pill

--- a/bundle/manifests/poison-pill.medik8s.io_poisonpillconfigs.yaml
+++ b/bundle/manifests/poison-pill.medik8s.io_poisonpillconfigs.yaml
@@ -39,7 +39,7 @@ spec:
                 minimum: 0
                 type: integer
               watchdogFilePath:
-                default: /dev/watchdog1
+                default: /dev/watchdog
                 description: WatchdogFilePath is the watchdog file path that should be available on each node, e.g. /dev/watchdog
                 type: string
             type: object

--- a/config/crd/bases/poison-pill.medik8s.io_poisonpillconfigs.yaml
+++ b/config/crd/bases/poison-pill.medik8s.io_poisonpillconfigs.yaml
@@ -51,7 +51,7 @@ spec:
                 minimum: 0
                 type: integer
               watchdogFilePath:
-                default: /dev/watchdog1
+                default: /dev/watchdog
                 description: WatchdogFilePath is the watchdog file path that should
                   be available on each node, e.g. /dev/watchdog
                 type: string

--- a/controllers/poisonpillconfig_controller.go
+++ b/controllers/poisonpillconfig_controller.go
@@ -106,7 +106,7 @@ func (r *PoisonPillConfigReconciler) syncConfigDaemonSet(ppc *poisonpillv1alpha1
 
 	watchdogPath := ppc.Spec.WatchdogFilePath
 	if watchdogPath == "" {
-		watchdogPath = "/dev/watchdog1"
+		watchdogPath = "/dev/watchdog"
 	}
 	data.Data["WatchdogPath"] = watchdogPath
 

--- a/controllers/poisonpillconfig_controller_test.go
+++ b/controllers/poisonpillconfig_controller_test.go
@@ -95,7 +95,7 @@ var _ = Describe("ppc controller Test", func() {
 				return k8sClient.Get(context.Background(), configKey, createdConfig)
 			}, 5*time.Second, 250*time.Millisecond).Should(BeNil())
 
-			Expect(createdConfig.Spec.WatchdogFilePath).To(Equal("/dev/watchdog1"))
+			Expect(createdConfig.Spec.WatchdogFilePath).To(Equal("/dev/watchdog"))
 			Expect(createdConfig.Spec.SafeTimeToAssumeNodeRebootedSeconds).To(Equal(180))
 		})
 	})

--- a/install/poison-pill-deamonset.yaml
+++ b/install/poison-pill-deamonset.yaml
@@ -16,6 +16,11 @@ spec:
         control-plane: controller-manager
         app: poison-pill-agent
     spec:
+      volumes:
+        - name: devices
+          hostPath:
+            path: /dev
+            type: Directory
       serviceAccountName: poison-pill-controller-manager
       priorityClassName: system-node-critical
       hostPID: true
@@ -39,6 +44,9 @@ spec:
             value: {{.TimeToAssumeNodeRebooted}}
         image: {{.Image}}
         imagePullPolicy: Always
+        volumeMounts:
+          - name: devices
+            mountPath: /dev
         securityContext:
           privileged: true
           hostPID: true


### PR DESCRIPTION
softdog provides better reliability comparing to software reboot
This PR tries to enable softdog in case the user provided watchdog doesn't exist