### PR TITLE
Exclude shutdown test from api-server health check

### DIFF
--- a/pkg/apicheck/check.go
+++ b/pkg/apicheck/check.go
@@ -66,7 +66,7 @@ func (c *ApiConnectivityCheck) Start(ctx context.Context) error {
 		readerCtx, cancel := context.WithTimeout(ctx, c.config.ApiServerTimeout)
 		defer cancel()
 
-		result := restClient.Verb(http.MethodGet).RequestURI("/readyz").Do(readerCtx)
+		result := restClient.Verb(http.MethodGet).RequestURI("/readyz?exclude=shutdown").Do(readerCtx)
 		failure := ""
 		if result.Error() != nil {
 			failure = fmt.Sprintf("api server readyz endpoint error: %v", result.Error())


### PR DESCRIPTION
we use the /readyz endpoint of the api-server to detect api-server health issues.
Sometime we see the check fails due to "shutdown failed: reason withheld" which means the api-server is still serving requests but might do a graceful shutdown.
This creates false positive which trigger the peers query even though it's not required.

