### PR TITLE
No software reboot mode new

### DIFF
--- a/api/v1alpha1/poisonpillconfig_types.go
+++ b/api/v1alpha1/poisonpillconfig_types.go
@@ -52,7 +52,7 @@ type PoisonPillConfigSpec struct {
 	// if the watchdog device can not be used or will use watchdog only,
 	// without a fallback to software reboot
 	// +kubebuilder:default=true
-	IsSoftwareRebootEnabled bool `json:"isSoftwareRebootEnabled ,omitempty"`
+	IsSoftwareRebootEnabled bool `json:"isSoftwareRebootEnabled,omitempty"`
 }
 
 // PoisonPillConfigStatus defines the observed state of PoisonPillConfig

--- a/api/v1alpha1/poisonpillconfig_types.go
+++ b/api/v1alpha1/poisonpillconfig_types.go
@@ -28,6 +28,7 @@ const (
 	templateCRName                        = "poison-pill-default-template"
 	defaultWatchdogPath                   = "/dev/watchdog"
 	defaultSafetToAssumeNodeRebootTimeout = 180
+	defaultIsSoftwareRebootEnabled        = true
 )
 
 // PoisonPillConfigSpec defines the desired state of PoisonPillConfig
@@ -46,6 +47,12 @@ type PoisonPillConfigSpec struct {
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:default=180
 	SafeTimeToAssumeNodeRebootedSeconds int `json:"safeTimeToAssumeNodeRebootedSeconds,omitempty"`
+
+	// IsSoftwareRebootEnabled indicates whether poison pill agent will do software reboot,
+	// if the watchdog device can not be used or will use watchdog only,
+	// without a fallback to software reboot
+	// +kubebuilder:default=true
+	IsSoftwareRebootEnabled bool `json:"isSoftwareRebootEnabled ,omitempty"`
 }
 
 // PoisonPillConfigStatus defines the observed state of PoisonPillConfig
@@ -86,6 +93,7 @@ func NewDefaultPoisonPillConfig() PoisonPillConfig {
 		Spec: PoisonPillConfigSpec{
 			WatchdogFilePath:                    defaultWatchdogPath,
 			SafeTimeToAssumeNodeRebootedSeconds: defaultSafetToAssumeNodeRebootTimeout,
+			IsSoftwareRebootEnabled:             defaultIsSoftwareRebootEnabled,
 		},
 	}
 }

--- a/config/crd/bases/poison-pill.medik8s.io_poisonpillconfigs.yaml
+++ b/config/crd/bases/poison-pill.medik8s.io_poisonpillconfigs.yaml
@@ -40,7 +40,7 @@ spec:
           spec:
             description: PoisonPillConfigSpec defines the desired state of PoisonPillConfig
             properties:
-              'isSoftwareRebootEnabled ':
+              isSoftwareRebootEnabled:
                 default: true
                 description: IsSoftwareRebootEnabled indicates whether poison pill
                   agent will do software reboot, if the watchdog device can not be

--- a/config/crd/bases/poison-pill.medik8s.io_poisonpillconfigs.yaml
+++ b/config/crd/bases/poison-pill.medik8s.io_poisonpillconfigs.yaml
@@ -40,6 +40,12 @@ spec:
           spec:
             description: PoisonPillConfigSpec defines the desired state of PoisonPillConfig
             properties:
+              'isSoftwareRebootEnabled ':
+                default: true
+                description: IsSoftwareRebootEnabled indicates whether poison pill
+                  agent will do software reboot, if the watchdog device can not be
+                  used or will use watchdog only, without a fallback to software reboot
+                type: boolean
               safeTimeToAssumeNodeRebootedSeconds:
                 default: 180
                 description: SafeTimeToAssumeNodeRebootedSeconds is the time after

--- a/controllers/controller_test.go
+++ b/controllers/controller_test.go
@@ -7,15 +7,15 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/medik8s/poison-pill/controllers"
 	poisonpillv1alpha1 "github.com/medik8s/poison-pill/api/v1alpha1"
+	"github.com/medik8s/poison-pill/controllers"
 )
 
 const (

--- a/controllers/poisonpillconfig_controller.go
+++ b/controllers/poisonpillconfig_controller.go
@@ -116,6 +116,9 @@ func (r *PoisonPillConfigReconciler) syncConfigDaemonSet(ppc *poisonpillv1alpha1
 	}
 	data.Data["TimeToAssumeNodeRebooted"] = fmt.Sprintf("\"%d\"", timeToAssumeNodeRebooted)
 
+	isSoftwareRebootEnabled := ppc.Spec.IsSoftwareRebootEnabled
+	data.Data["IsSoftwareRebootEnabled"] = fmt.Sprintf("%t", isSoftwareRebootEnabled)
+
 	objs, err := render.RenderDir(r.InstallFileFolder, &data)
 	if err != nil {
 		logger.Error(err, "Fail to render config daemon manifests")

--- a/controllers/poisonpillconfig_controller.go
+++ b/controllers/poisonpillconfig_controller.go
@@ -116,8 +116,7 @@ func (r *PoisonPillConfigReconciler) syncConfigDaemonSet(ppc *poisonpillv1alpha1
 	}
 	data.Data["TimeToAssumeNodeRebooted"] = fmt.Sprintf("\"%d\"", timeToAssumeNodeRebooted)
 
-	isSoftwareRebootEnabled := ppc.Spec.IsSoftwareRebootEnabled
-	data.Data["IsSoftwareRebootEnabled"] = fmt.Sprintf("%t", isSoftwareRebootEnabled)
+	data.Data["IsSoftwareRebootEnabled"] = fmt.Sprintf("\"%t\"", ppc.Spec.IsSoftwareRebootEnabled)
 
 	objs, err := render.RenderDir(r.InstallFileFolder, &data)
 	if err != nil {

--- a/controllers/poisonpillremediation_controller.go
+++ b/controllers/poisonpillremediation_controller.go
@@ -28,9 +28,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/selection"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -256,24 +254,16 @@ func (r *PoisonPillRemediationReconciler) Reconcile(ctx context.Context, req ctr
 }
 
 func (r *PoisonPillRemediationReconciler) hasPoisonPillAgentPod(node *v1.Node) (bool, error) {
-	podList := &v1.PodList{}
-
-	selector := labels.NewSelector()
-	requirement, _ := labels.NewRequirement("app", selection.Equals, []string{"poison-pill-agent"})
-	selector = selector.Add(*requirement)
-
-	err := r.Client.List(context.Background(), podList, &client.ListOptions{LabelSelector: selector})
+	pod, err := utils.GetPoisonPillAgentPod(node.Name, r.Client)
 	if err != nil {
 		r.logger.Error(err, "failed to list poison pill agent pods")
 		return false, err
 	}
 
-	for _, pod := range podList.Items {
-		if pod.Spec.NodeName == node.Name {
-			return true, nil
-		}
+	if pod == nil {
+		return false, nil
 	}
-	return false, nil
+	return true, nil
 }
 
 //returns the lastHeartbeatTime of the first condition, if exists. Otherwise returns the zero value

--- a/controllers/poisonpillremediation_controller.go
+++ b/controllers/poisonpillremediation_controller.go
@@ -253,7 +253,7 @@ func (r *PoisonPillRemediationReconciler) Reconcile(ctx context.Context, req ctr
 	return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 }
 
-func (r *PoisonPillRemediationReconciler) hasPoisohasRunningPoisonPillAgentPodnPillAgentPod(node *v1.Node) (bool, error) {
+func (r *PoisonPillRemediationReconciler) hasRunningPoisonPillAgentPod(node *v1.Node) (bool, error) {
 	pod, err := utils.GetPoisonPillAgentPod(node.Name, r.Client)
 	if err != nil {
 		r.logger.Error(err, "failed to list poison pill agent pods")

--- a/install/poison-pill-deamonset.yaml
+++ b/install/poison-pill-deamonset.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         control-plane: controller-manager
         app: poison-pill-agent
+        is-reboot-capable: unknown
     spec:
       volumes:
         - name: devices

--- a/install/poison-pill-deamonset.yaml
+++ b/install/poison-pill-deamonset.yaml
@@ -42,6 +42,8 @@ spec:
             value: {{.WatchdogPath}}
           - name: TIME_TO_ASSUME_NODE_REBOOTED
             value: {{.TimeToAssumeNodeRebooted}}
+          - name: IS_SOFTWARE_REBOOT_ENABLED
+            value: {{.IsSoftwareRebootEnabled}}
         image: {{.Image}}
         imagePullPolicy: Always
         volumeMounts:

--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/medik8s/poison-pill/pkg/utils"
+	v1 "k8s.io/api/core/v1"
 	"os"
 	"strconv"
 	"time"
@@ -175,6 +177,7 @@ func initPoisonPillAgent(mgr manager.Manager) {
 		os.Exit(1)
 	}
 
+	watchdogInitiated := false
 	wd, err := watchdog.NewLinux(ctrl.Log.WithName("watchdog"))
 	if err != nil {
 		setupLog.Error(err, "failed to init watchdog, using soft reboot")
@@ -185,6 +188,12 @@ func initPoisonPillAgent(mgr manager.Manager) {
 			os.Exit(1)
 		}
 	}
+	watchdogInitiated = true
+	if err = updatePodIsRebootCapableLabel(watchdogInitiated, myNodeName, mgr.GetClient()); err != nil {
+		setupLog.Error(err, "failed to update pod's 'is-reboot-capable' label")
+		os.Exit(1)
+	}
+
 	// it's fine when the watchdog is nil!
 	rebooter := reboot.NewWatchdogRebooter(wd, ctrl.Log.WithName("rebooter"))
 
@@ -328,4 +337,40 @@ func getDeploymentNamespace() (string, error) {
 		return "", fmt.Errorf("%s must be set", deployNamespaceEnvVar)
 	}
 	return ns, nil
+}
+
+//updatePodIsRebootCapableLabel updates the is-reboot-capable label to be true if any kind
+// of reboot is enabled and false if there isn't watchdog and software reboot is disabled
+func updatePodIsRebootCapableLabel(watchdogInitiated bool, nodeName string, client client.Client) error {
+	//get pod in order to update it's label
+	pod, err := utils.GetPoisonPillAgentPod(nodeName, client)
+	if err != nil {
+		setupLog.Error(err, "failed to list poison pill agent pods")
+		return err
+	}
+
+	softwareRebootEnabledEnv := os.Getenv("SOFTWARE_REBOOT_ENABLED")
+	softwareRebootEnabled, err := strconv.ParseBool(softwareRebootEnabledEnv)
+	if err != nil {
+		setupLog.Error(err, "failed to convert env variable SOFTWARE_REBOOT_ENABLED value: %s to boolean",
+			softwareRebootEnabledEnv)
+		return err
+	}
+	if watchdogInitiated || softwareRebootEnabled {
+		err = updateLabel("is-reboot-capable", "true", pod, client)
+		return err
+	}
+
+	err = updateLabel("is-reboot-capable", "false", pod, client)
+	return err
+}
+
+func updateLabel(labelKey string, labelValue string, pod *v1.Pod, c client.Client) error {
+	if pod.Labels == nil {
+		pod.Labels = map[string]string{}
+	}
+	pod.Labels[labelKey] = labelValue
+	//update in yaml
+	err := c.Update(context.Background(), pod)
+	return err
 }

--- a/pkg/utils/pods.go
+++ b/pkg/utils/pods.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"context"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetPoisonPillAgentPod(nodeName string, c client.Client) (*v1.Pod, error) {
+	podList := &v1.PodList{}
+
+	selector := labels.NewSelector()
+	requirement, _ := labels.NewRequirement("app", selection.Equals, []string{"poison-pill-agent"})
+	selector = selector.Add(*requirement)
+
+	err := c.List(context.Background(), podList, &client.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, pod := range podList.Items {
+		if pod.Spec.NodeName == nodeName {
+			return &pod, nil
+		}
+	}
+	return nil, nil
+}


### PR DESCRIPTION
allow no-software-reboot mode.
update poison pill agent's label "is-reboot-capable" to be true if there's watchdog or software reboot wasn't disabled by the user (in the IsSoftwareRebootEnabled env). Otherwise, update the label to be false. 