### PR TITLE
[bug 1999730] restore node only after 90 seconds

### DIFF
--- a/controllers/controller_test.go
+++ b/controllers/controller_test.go
@@ -216,7 +216,7 @@ var _ = Describe("ppr Controller", func() {
 					return true
 				}
 				return node.Spec.Unschedulable
-			}, 5*time.Second, 250*time.Millisecond).Should(BeFalse())
+			}, 95*time.Second, 250*time.Millisecond).Should(BeFalse())
 		})
 
 		It("Verify that finalizer exists until node updates status", func() {


### PR DESCRIPTION
we need to restore the node only after the cluster realized it can reschecudle the affected workloads
as of writing this lines, kubernetes will check for pods with non-existent node once in 20s, and allows 40s of grace period for the node to reappear before it deletes the pods.
see here: https://github.com/kubernetes/kubernetes/blob/7a0638da76cb9843def65708b661d2c6aa58ed5a/pkg/controller/podgc/gc_controller.go#L43-L47

This commit introduce time to wait before we restore the node to let the cluster delete the pods.
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1999730
