### PR TITLE
Include release-* branches when pushing tags

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - 'release-*'
     tags:
       - 'v*'
   release:


### PR DESCRIPTION
tags are pushed to release branches - this change should make sure github publishes official version containers on it.