### PR TITLE
Add new remediation strategy - pod and volumeattachments deletion

### DIFF
--- a/api/v1alpha1/poisonpillremediation_types.go
+++ b/api/v1alpha1/poisonpillremediation_types.go
@@ -22,8 +22,8 @@ import (
 )
 
 const (
-	NodeDeletionRemdiationStrategy       = RemediationStrategyType("NodeDeletion")
-	ResourcesDeletionRemediationStrategy = RemediationStrategyType("ResourcesDeletion")
+	NodeDeletionRemediationStrategy     = RemediationStrategyType("NodeDeletion")
+	ResourceDeletionRemediationStrategy = RemediationStrategyType("ResourceDeletion")
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -34,11 +34,11 @@ type RemediationStrategyType string
 // PoisonPillRemediationSpec defines the desired state of PoisonPillRemediation
 type PoisonPillRemediationSpec struct {
 	//RemediationStrategy is the remediation method for unhealthy nodes
-	//could be either "NodeDeletion" or "ResourcesDeletion"
+	//could be either "NodeDeletion" or "ResourceDeletion"
 	//the first will delete the node to signal to the cluster that the node was fenced
 	//the latter will iterate over all pos and volumeattachments related to the unhealthy node and delete them
 	// +kubebuilder:default:="NodeDeletion"
-	// +kubebuilder:validation:Enum=NodeDeletion;ResourcesDeletion
+	// +kubebuilder:validation:Enum=NodeDeletion;ResourceDeletion
 	RemediationStrategy RemediationStrategyType `json:"remediationStrategy,omitempty"`
 }
 

--- a/api/v1alpha1/poisonpillremediation_types.go
+++ b/api/v1alpha1/poisonpillremediation_types.go
@@ -21,6 +21,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	NodeDeletionRemdiationStrategy       = RemediationStrategyType("NodeDeletion")
+	ResourcesDeletionRemediationStrategy = RemediationStrategyType("ResourcesDeletion")
+)
+
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 

--- a/api/v1alpha1/poisonpillremediation_types.go
+++ b/api/v1alpha1/poisonpillremediation_types.go
@@ -24,9 +24,17 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+type RemediationStrategyType string
+
 // PoisonPillRemediationSpec defines the desired state of PoisonPillRemediation
 type PoisonPillRemediationSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
+	//RemediationStrategy is the remediation method for unhealthy nodes
+	//could be either "NodeDeletion" or "ResourcesDeletion"
+	//the first will delete the node to signal to the cluster that the node was fenced
+	//the latter will iterate over all pos and volumeattachments related to the unhealthy node and delete them
+	// +kubebuilder:default:="NodeDeletion"
+	RemediationStrategy RemediationStrategyType `json:"remediationStrategy,omitempty"`
 }
 
 // PoisonPillRemediationStatus defines the observed state of PoisonPillRemediation

--- a/api/v1alpha1/poisonpillremediation_types.go
+++ b/api/v1alpha1/poisonpillremediation_types.go
@@ -28,12 +28,12 @@ type RemediationStrategyType string
 
 // PoisonPillRemediationSpec defines the desired state of PoisonPillRemediation
 type PoisonPillRemediationSpec struct {
-	// Important: Run "make" to regenerate code after modifying this file
 	//RemediationStrategy is the remediation method for unhealthy nodes
 	//could be either "NodeDeletion" or "ResourcesDeletion"
 	//the first will delete the node to signal to the cluster that the node was fenced
 	//the latter will iterate over all pos and volumeattachments related to the unhealthy node and delete them
 	// +kubebuilder:default:="NodeDeletion"
+	// +kubebuilder:validation:Enum=NodeDeletion;ResourcesDeletion
 	RemediationStrategy RemediationStrategyType `json:"remediationStrategy,omitempty"`
 }
 

--- a/bundle/manifests/poison-pill.clusterserviceversion.yaml
+++ b/bundle/manifests/poison-pill.clusterserviceversion.yaml
@@ -120,6 +120,8 @@ spec:
           resources:
           - pods
           verbs:
+          - delete
+          - deletecollection
           - get
           - list
           - update
@@ -242,6 +244,17 @@ spec:
           - securitycontextconstraints
           verbs:
           - use
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - volumeattachments
+          verbs:
+          - delete
+          - deletecollection
+          - get
+          - list
+          - update
+          - watch
         - apiGroups:
           - authentication.k8s.io
           resources:

--- a/bundle/manifests/poison-pill.medik8s.io_poisonpillremediations.yaml
+++ b/bundle/manifests/poison-pill.medik8s.io_poisonpillremediations.yaml
@@ -37,6 +37,18 @@ spec:
             type: object
           spec:
             description: PoisonPillRemediationSpec defines the desired state of PoisonPillRemediation
+            properties:
+              remediationStrategy:
+                default: NodeDeletion
+                description: RemediationStrategy is the remediation method for unhealthy
+                  nodes could be either "NodeDeletion" or "ResourcesDeletion" the
+                  first will delete the node to signal to the cluster that the node
+                  was fenced the latter will iterate over all pos and volumeattachments
+                  related to the unhealthy node and delete them
+                enum:
+                - NodeDeletion
+                - ResourcesDeletion
+                type: string
             type: object
           status:
             description: PoisonPillRemediationStatus defines the observed state of

--- a/bundle/manifests/poison-pill.medik8s.io_poisonpillremediations.yaml
+++ b/bundle/manifests/poison-pill.medik8s.io_poisonpillremediations.yaml
@@ -41,13 +41,13 @@ spec:
               remediationStrategy:
                 default: NodeDeletion
                 description: RemediationStrategy is the remediation method for unhealthy
-                  nodes could be either "NodeDeletion" or "ResourcesDeletion" the
-                  first will delete the node to signal to the cluster that the node
-                  was fenced the latter will iterate over all pos and volumeattachments
+                  nodes could be either "NodeDeletion" or "ResourceDeletion" the first
+                  will delete the node to signal to the cluster that the node was
+                  fenced the latter will iterate over all pos and volumeattachments
                   related to the unhealthy node and delete them
                 enum:
                 - NodeDeletion
-                - ResourcesDeletion
+                - ResourceDeletion
                 type: string
             type: object
           status:

--- a/bundle/manifests/poison-pill.medik8s.io_poisonpillremediationtemplates.yaml
+++ b/bundle/manifests/poison-pill.medik8s.io_poisonpillremediationtemplates.yaml
@@ -45,6 +45,19 @@ spec:
                   spec:
                     description: PoisonPillRemediationSpec defines the desired state
                       of PoisonPillRemediation
+                    properties:
+                      remediationStrategy:
+                        default: NodeDeletion
+                        description: RemediationStrategy is the remediation method
+                          for unhealthy nodes could be either "NodeDeletion" or "ResourcesDeletion"
+                          the first will delete the node to signal to the cluster
+                          that the node was fenced the latter will iterate over all
+                          pos and volumeattachments related to the unhealthy node
+                          and delete them
+                        enum:
+                        - NodeDeletion
+                        - ResourcesDeletion
+                        type: string
                     type: object
                 required:
                 - spec

--- a/bundle/manifests/poison-pill.medik8s.io_poisonpillremediationtemplates.yaml
+++ b/bundle/manifests/poison-pill.medik8s.io_poisonpillremediationtemplates.yaml
@@ -49,14 +49,14 @@ spec:
                       remediationStrategy:
                         default: NodeDeletion
                         description: RemediationStrategy is the remediation method
-                          for unhealthy nodes could be either "NodeDeletion" or "ResourcesDeletion"
+                          for unhealthy nodes could be either "NodeDeletion" or "ResourceDeletion"
                           the first will delete the node to signal to the cluster
                           that the node was fenced the latter will iterate over all
                           pos and volumeattachments related to the unhealthy node
                           and delete them
                         enum:
                         - NodeDeletion
-                        - ResourcesDeletion
+                        - ResourceDeletion
                         type: string
                     type: object
                 required:

--- a/config/crd/bases/poison-pill.medik8s.io_poisonpillremediations.yaml
+++ b/config/crd/bases/poison-pill.medik8s.io_poisonpillremediations.yaml
@@ -39,6 +39,16 @@ spec:
             type: object
           spec:
             description: PoisonPillRemediationSpec defines the desired state of PoisonPillRemediation
+            properties:
+              remediationStrategy:
+                default: NodeDeletion
+                description: 'Important: Run "make" to regenerate code after modifying
+                  this file RemediationStrategy is the remediation method for unhealthy
+                  nodes could be either "NodeDeletion" or "ResourcesDeletion" the
+                  first will delete the node to signal to the cluster that the node
+                  was fenced the latter will iterate over all pos and volumeattachments
+                  related to the unhealthy node and delete them'
+                type: string
             type: object
           status:
             description: PoisonPillRemediationStatus defines the observed state of

--- a/config/crd/bases/poison-pill.medik8s.io_poisonpillremediations.yaml
+++ b/config/crd/bases/poison-pill.medik8s.io_poisonpillremediations.yaml
@@ -42,12 +42,14 @@ spec:
             properties:
               remediationStrategy:
                 default: NodeDeletion
-                description: 'Important: Run "make" to regenerate code after modifying
-                  this file RemediationStrategy is the remediation method for unhealthy
+                description: RemediationStrategy is the remediation method for unhealthy
                   nodes could be either "NodeDeletion" or "ResourcesDeletion" the
                   first will delete the node to signal to the cluster that the node
                   was fenced the latter will iterate over all pos and volumeattachments
-                  related to the unhealthy node and delete them'
+                  related to the unhealthy node and delete them
+                enum:
+                - NodeDeletion
+                - ResourcesDeletion
                 type: string
             type: object
           status:

--- a/config/crd/bases/poison-pill.medik8s.io_poisonpillremediations.yaml
+++ b/config/crd/bases/poison-pill.medik8s.io_poisonpillremediations.yaml
@@ -43,13 +43,13 @@ spec:
               remediationStrategy:
                 default: NodeDeletion
                 description: RemediationStrategy is the remediation method for unhealthy
-                  nodes could be either "NodeDeletion" or "ResourcesDeletion" the
-                  first will delete the node to signal to the cluster that the node
-                  was fenced the latter will iterate over all pos and volumeattachments
+                  nodes could be either "NodeDeletion" or "ResourceDeletion" the first
+                  will delete the node to signal to the cluster that the node was
+                  fenced the latter will iterate over all pos and volumeattachments
                   related to the unhealthy node and delete them
                 enum:
                 - NodeDeletion
-                - ResourcesDeletion
+                - ResourceDeletion
                 type: string
             type: object
           status:

--- a/config/crd/bases/poison-pill.medik8s.io_poisonpillremediationtemplates.yaml
+++ b/config/crd/bases/poison-pill.medik8s.io_poisonpillremediationtemplates.yaml
@@ -50,13 +50,15 @@ spec:
                     properties:
                       remediationStrategy:
                         default: NodeDeletion
-                        description: 'Important: Run "make" to regenerate code after
-                          modifying this file RemediationStrategy is the remediation
-                          method for unhealthy nodes could be either "NodeDeletion"
-                          or "ResourcesDeletion" the first will delete the node to
-                          signal to the cluster that the node was fenced the latter
-                          will iterate over all pos and volumeattachments related
-                          to the unhealthy node and delete them'
+                        description: RemediationStrategy is the remediation method
+                          for unhealthy nodes could be either "NodeDeletion" or "ResourcesDeletion"
+                          the first will delete the node to signal to the cluster
+                          that the node was fenced the latter will iterate over all
+                          pos and volumeattachments related to the unhealthy node
+                          and delete them
+                        enum:
+                        - NodeDeletion
+                        - ResourcesDeletion
                         type: string
                     type: object
                 required:

--- a/config/crd/bases/poison-pill.medik8s.io_poisonpillremediationtemplates.yaml
+++ b/config/crd/bases/poison-pill.medik8s.io_poisonpillremediationtemplates.yaml
@@ -47,6 +47,17 @@ spec:
                   spec:
                     description: PoisonPillRemediationSpec defines the desired state
                       of PoisonPillRemediation
+                    properties:
+                      remediationStrategy:
+                        default: NodeDeletion
+                        description: 'Important: Run "make" to regenerate code after
+                          modifying this file RemediationStrategy is the remediation
+                          method for unhealthy nodes could be either "NodeDeletion"
+                          or "ResourcesDeletion" the first will delete the node to
+                          signal to the cluster that the node was fenced the latter
+                          will iterate over all pos and volumeattachments related
+                          to the unhealthy node and delete them'
+                        type: string
                     type: object
                 required:
                 - spec

--- a/config/crd/bases/poison-pill.medik8s.io_poisonpillremediationtemplates.yaml
+++ b/config/crd/bases/poison-pill.medik8s.io_poisonpillremediationtemplates.yaml
@@ -51,14 +51,14 @@ spec:
                       remediationStrategy:
                         default: NodeDeletion
                         description: RemediationStrategy is the remediation method
-                          for unhealthy nodes could be either "NodeDeletion" or "ResourcesDeletion"
+                          for unhealthy nodes could be either "NodeDeletion" or "ResourceDeletion"
                           the first will delete the node to signal to the cluster
                           that the node was fenced the latter will iterate over all
                           pos and volumeattachments related to the unhealthy node
                           and delete them
                         enum:
                         - NodeDeletion
-                        - ResourcesDeletion
+                        - ResourceDeletion
                         type: string
                     type: object
                 required:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -41,6 +41,8 @@ rules:
   resources:
   - pods
   verbs:
+  - delete
+  - deletecollection
   - get
   - list
   - update
@@ -55,6 +57,16 @@ rules:
   - get
   - list
   - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - volumeattachments
+  verbs:
+  - delete
+  - get
+  - list
   - update
   - watch
 - apiGroups:
@@ -163,3 +175,14 @@ rules:
   - securitycontextconstraints
   verbs:
   - use
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - delete
+  - deletecollection
+  - get
+  - list
+  - update
+  - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -60,16 +60,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - volumeattachments
-  verbs:
-  - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
   - machine.openshift.io
   resources:
   - machines

--- a/controllers/poisonpillremediation_controller.go
+++ b/controllers/poisonpillremediation_controller.go
@@ -219,17 +219,17 @@ func (r *PoisonPillRemediationReconciler) remediateWithResourcesDeletion(ppr *v1
 		}
 	}
 
-	volumeattachments := storagev1.VolumeAttachmentList{}
-	if err := r.Client.List(context.Background(), &volumeattachments); err != nil {
-		r.logger.Error(err, "failed to get volumeattachments list")
+	volumeAttachments := &storagev1.VolumeAttachmentList{}
+	if err := r.Client.List(context.Background(), volumeAttachments); err != nil {
+		r.logger.Error(err, "failed to get volumeAttachments list")
 		return ctrl.Result{}, err
 	}
 
-	for _, va := range volumeattachments.Items {
+	for _, va := range volumeAttachments.Items {
 		if va.Spec.NodeName == node.Name {
 			err = r.Client.Delete(context.Background(), &va)
 			if err != nil {
-				r.logger.Error(err, "failed to delete volumeattachment", "name", va.Name)
+				r.logger.Error(err, "failed to delete volumeAttachment", "name", va.Name)
 				return ctrl.Result{}, err
 			}
 		}
@@ -356,7 +356,7 @@ func (r *PoisonPillRemediationReconciler) remediateWithNodeDeletion(ppr *v1alpha
 	return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 }
 
-//wasNodeRebooted returns true if the node assumed to been rebooted.
+// wasNodeRebooted returns true if the node assumed to been rebooted.
 // if not, it will also return the remaining time for that to happen
 func (r *PoisonPillRemediationReconciler) wasNodeRebooted(ppr *v1alpha1.PoisonPillRemediation) (bool, time.Duration) {
 	maxNodeRebootTime := ppr.Status.TimeAssumedRebooted

--- a/controllers/poisonpillremediation_controller.go
+++ b/controllers/poisonpillremediation_controller.go
@@ -159,7 +159,8 @@ func (r *PoisonPillRemediationReconciler) remediateWithResourcesDeletion(ppr *v1
 	}
 
 	if !r.isNodeRebootCapable(node) {
-		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		//use err to trigger exponential backoff
+		return ctrl.Result{}, errors.New("Node is not capable to reboot itself")
 	}
 
 	if !controllerutil.ContainsFinalizer(ppr, PPRFinalizer) {
@@ -313,7 +314,7 @@ func (r *PoisonPillRemediationReconciler) remediateWithNodeDeletion(ppr *v1alpha
 	}
 
 	if !r.isNodeRebootCapable(node) {
-		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		return ctrl.Result{}, errors.New("Node is not capable to reboot itself")
 	}
 
 	if !controllerutil.ContainsFinalizer(ppr, PPRFinalizer) {

--- a/controllers/poisonpillremediation_controller.go
+++ b/controllers/poisonpillremediation_controller.go
@@ -127,10 +127,10 @@ func (r *PoisonPillRemediationReconciler) Reconcile(ctx context.Context, req ctr
 	r.mutex.Unlock()
 
 	switch ppr.Spec.RemediationStrategy {
-	case v1alpha1.NodeDeletionRemdiationStrategy:
+	case v1alpha1.NodeDeletionRemediationStrategy:
 		return r.remediateWithNodeDeletion(ppr)
-	case v1alpha1.ResourcesDeletionRemediationStrategy:
-		return r.remediateWithResourcesDeletion(ppr)
+	case v1alpha1.ResourceDeletionRemediationStrategy:
+		return r.remediateWithResourceDeletion(ppr)
 	default:
 		r.logger.Info("Encountered unsupported remediation strategy. Please check template spec", "strategy", ppr.Spec.RemediationStrategy)
 	}
@@ -142,7 +142,7 @@ func (r *PoisonPillRemediationReconciler) isPprCompleted(ppr *v1alpha1.PoisonPil
 	return ppr.Status.Phase != nil && *ppr.Status.Phase == completedPhase
 }
 
-func (r *PoisonPillRemediationReconciler) remediateWithResourcesDeletion(ppr *v1alpha1.PoisonPillRemediation) (ctrl.Result, error) {
+func (r *PoisonPillRemediationReconciler) remediateWithResourceDeletion(ppr *v1alpha1.PoisonPillRemediation) (ctrl.Result, error) {
 	if r.isPprCompleted(ppr) {
 		if controllerutil.ContainsFinalizer(ppr, PPRFinalizer) {
 			if err := r.removeFinalizer(ppr); err != nil {

--- a/controllers/poisonpillremediation_controller.go
+++ b/controllers/poisonpillremediation_controller.go
@@ -127,9 +127,9 @@ func (r *PoisonPillRemediationReconciler) Reconcile(ctx context.Context, req ctr
 	r.mutex.Unlock()
 
 	switch ppr.Spec.RemediationStrategy {
-	case "NodeDeletion":
+	case v1alpha1.NodeDeletionRemdiationStrategy:
 		return r.remediateWithNodeDeletion(ppr)
-	case "ResourcesDeletion":
+	case v1alpha1.ResourcesDeletionRemediationStrategy:
 		return r.remediateWithResourcesDeletion(ppr)
 	default:
 		r.logger.Info("Encountered unsupported remediation strategy. Please check template spec", "strategy", ppr.Spec.RemediationStrategy)

--- a/controllers/poisonpillremediation_controller.go
+++ b/controllers/poisonpillremediation_controller.go
@@ -143,15 +143,12 @@ func (r *PoisonPillRemediationReconciler) isPprCompleted(ppr *v1alpha1.PoisonPil
 }
 
 func (r *PoisonPillRemediationReconciler) remediateWithResourcesDeletion(ppr *v1alpha1.PoisonPillRemediation) (ctrl.Result, error) {
-	if controllerutil.ContainsFinalizer(ppr, PPRFinalizer) {
-		if r.isPprCompleted(ppr) { //remediation done
+	if r.isPprCompleted(ppr) {
+		if controllerutil.ContainsFinalizer(ppr, PPRFinalizer) {
 			if err := r.removeFinalizer(ppr); err != nil {
 				return ctrl.Result{}, err
 			}
 		}
-	}
-
-	if r.isPprCompleted(ppr) {
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/poisonpillremediation_controller.go
+++ b/controllers/poisonpillremediation_controller.go
@@ -18,14 +18,16 @@ package controllers
 
 import (
 	"context"
-	"errors"
+	"k8s.io/apimachinery/pkg/fields"
 	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 
 	machinev1beta1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -45,6 +47,7 @@ const (
 	//40s of grace period for the node to reappear before it deletes the pods.
 	//see here: https://github.com/kubernetes/kubernetes/blob/7a0638da76cb9843def65708b661d2c6aa58ed5a/pkg/controller/podgc/gc_controller.go#L43-L47
 	restoreNodeAfter = 90 * time.Second
+	completedPhase   = "Completed"
 )
 
 var (
@@ -94,7 +97,8 @@ func (r *PoisonPillRemediationReconciler) SetupWithManager(mgr ctrl.Manager) err
 		Complete(r)
 }
 
-//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;update
+//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;update;delete;deletecollection
+//+kubebuilder:rbac:groups=storage.k8s.io,resources=volumeattachments,verbs=get;list;watch;update;delete;deletecollection
 //+kubebuilder:rbac:groups=poison-pill.medik8s.io,resources=poisonpillremediationtemplates,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=poison-pill.medik8s.io,resources=poisonpillremediationtemplates/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=poison-pill.medik8s.io,resources=poisonpillremediationtemplates/finalizers,verbs=update
@@ -122,6 +126,144 @@ func (r *PoisonPillRemediationReconciler) Reconcile(ctx context.Context, req ctr
 	lastSeenPprNamespace = req.Namespace
 	r.mutex.Unlock()
 
+	switch ppr.Spec.RemediationStrategy {
+	case "NodeDeletion":
+		return r.remediateWithNodeDeletion(ppr)
+	case "ResourcesDeletion":
+		return r.remediateWithResourcesDeletion(ppr)
+	default:
+		r.logger.Info("Encountered unsupported remediation strategy. Please check template spec", "strategy", ppr.Spec.RemediationStrategy)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *PoisonPillRemediationReconciler) isPprCompleted(ppr *v1alpha1.PoisonPillRemediation) bool {
+	return ppr.Status.Phase != nil && *ppr.Status.Phase == completedPhase
+}
+
+func (r *PoisonPillRemediationReconciler) remediateWithResourcesDeletion(ppr *v1alpha1.PoisonPillRemediation) (ctrl.Result, error) {
+	if controllerutil.ContainsFinalizer(ppr, PPRFinalizer) {
+		if r.isPprCompleted(ppr) { //remediation done
+			if err := r.removeFinalizer(ppr); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	}
+
+	if r.isPprCompleted(ppr) {
+		return ctrl.Result{}, nil
+	}
+
+	node, err := r.getNodeFromPpr(ppr)
+	if err != nil {
+		r.logger.Error(err, "failed to get node", "node name", ppr.Name)
+		return ctrl.Result{}, err
+	}
+
+	if !r.isNodeRebootCapable(node) {
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
+	if !controllerutil.ContainsFinalizer(ppr, PPRFinalizer) {
+		return r.addFinalizer(ppr)
+	}
+
+	if !node.Spec.Unschedulable || !utils.TaintExists(node.Spec.Taints, NodeUnschedulableTaint) {
+		return r.markNodeAsUnschedulable(node)
+	}
+
+	if ppr.Status.TimeAssumedRebooted.IsZero() {
+		//todo this also updates the node but we don't need it
+		return r.updatePprStatus(node, ppr)
+	}
+
+	if r.MyNodeName == node.Name {
+		// we have a problem on this node, reboot!
+		return ctrl.Result{}, r.Rebooter.Reboot()
+	}
+
+	wasRebooted, timeLeft := r.wasNodeRebooted(ppr)
+	if !wasRebooted {
+		return ctrl.Result{RequeueAfter: timeLeft}, nil
+	}
+
+	r.logger.Info("TimeAssumedRebooted is old. The unhealthy node assumed to been rebooted", "node name", node.Name)
+
+	//fence
+	zero := int64(0)
+	backgroundDeletePolicy := metav1.DeletePropagationBackground
+
+	deleteOptions := &client.DeleteAllOfOptions{
+		ListOptions: client.ListOptions{
+			FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": node.Name}),
+			Namespace:     "",
+			Limit:         0,
+		},
+		DeleteOptions: client.DeleteOptions{
+			GracePeriodSeconds: &zero,
+			PropagationPolicy:  &backgroundDeletePolicy,
+		},
+	}
+
+	namespaces := v1.NamespaceList{}
+	if err := r.Client.List(context.Background(), &namespaces); err != nil {
+		r.logger.Error(err, "failed to list namespaces", err)
+		return ctrl.Result{}, err
+	}
+
+	pod := &v1.Pod{}
+	for _, ns := range namespaces.Items {
+		deleteOptions.Namespace = ns.Name
+		err = r.Client.DeleteAllOf(context.Background(), pod, deleteOptions)
+		if err != nil {
+			r.logger.Error(err, "failed to delete pods of unhealthy node", "namespace", ns.Name)
+			return ctrl.Result{}, err
+		}
+	}
+
+	volumeattachments := storagev1.VolumeAttachmentList{}
+	if err := r.Client.List(context.Background(), &volumeattachments); err != nil {
+		r.logger.Error(err, "failed to get volumeattachments list")
+		return ctrl.Result{}, err
+	}
+
+	for _, va := range volumeattachments.Items {
+		if va.Spec.NodeName == node.Name {
+			err = r.Client.Delete(context.Background(), &va)
+			if err != nil {
+				r.logger.Error(err, "failed to delete volumeattachment", "name", va.Name)
+				return ctrl.Result{}, err
+			}
+		}
+	}
+
+	if node.Spec.Unschedulable {
+		node.Spec.Unschedulable = false
+		if err := r.Client.Update(context.Background(), node); err != nil {
+			if apiErrors.IsConflict(err) {
+				return ctrl.Result{RequeueAfter: time.Second}, nil
+			}
+			r.logger.Error(err, "failed to mark node as schedulable")
+			return ctrl.Result{}, err
+		}
+	}
+
+	completed := completedPhase
+	ppr.Status.Phase = &completed
+	if err := r.Client.Status().Update(context.Background(), ppr); err != nil {
+		if apiErrors.IsConflict(err) {
+			// conflicts are expected since all poison pill deamonset pods are competing on the same requests
+			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+		}
+		r.logger.Error(err, "failed to mark PPR as completed")
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *PoisonPillRemediationReconciler) remediateWithNodeDeletion(ppr *v1alpha1.PoisonPillRemediation) (ctrl.Result, error) {
 	node, err := r.getNodeFromPpr(ppr)
 	if err != nil {
 		if apiErrors.IsNotFound(err) {
@@ -161,12 +303,7 @@ func (r *PoisonPillRemediationReconciler) Reconcile(ctx context.Context, req ctr
 				return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
 			}
 
-			controllerutil.RemoveFinalizer(ppr, PPRFinalizer)
-			if err := r.Client.Update(context.Background(), ppr); err != nil {
-				if apiErrors.IsConflict(err) {
-					return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
-				}
-				r.logger.Error(err, "failed to remove finalizer from ppr")
+			if err := r.removeFinalizer(ppr); err != nil {
 				return ctrl.Result{}, err
 			}
 		}
@@ -178,73 +315,31 @@ func (r *PoisonPillRemediationReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, nil
 	}
 
-	//make sure that the unhealthy node has poison pill pod on it which can reboot it
-	if _, err := utils.GetPoisonPillAgentPod(node.Name, r.Client); err != nil {
-		r.logger.Error(err, "failed to get poison pill agent pod resource")
-		return ctrl.Result{}, err
-	}
 
-	//if the unhealthy node has the poison pill agent pod, but the is-reboot-capable annotation is unknown/false/doesn't exist
-	//the node might not reboot, and we might end up in deleting a running node
-	if node.Annotations == nil || node.Annotations[utils.IsRebootCapableAnnotation] != "true" {
-		annVal := ""
-		if node.Annotations != nil {
-			annVal = node.Annotations[utils.IsRebootCapableAnnotation]
-		}
-		r.logger.Error(errors.New("node's isRebootCapable annotation is not `true`, which means the node might not reboot when we'll delete the node. Skipping remediation"),
-			"", "annotation value", annVal)
-		return ctrl.Result{}, nil
+	if !r.isNodeRebootCapable(node) {
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	if !controllerutil.ContainsFinalizer(ppr, PPRFinalizer) {
-		if !ppr.DeletionTimestamp.IsZero() {
-			//ppr is going to be deleted before we started any remediation action, so taking no-op
-			//otherwise we continue the remediation even if the deletionTimestamp is not zero
-			r.logger.Info("ppr is about to be deleted, which means the resource is healthy again. taking no-op")
-			return ctrl.Result{}, nil
-		}
-
-		controllerutil.AddFinalizer(ppr, PPRFinalizer)
-		if err := r.Client.Update(context.Background(), ppr); err != nil {
-			if apiErrors.IsConflict(err) {
-				return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
-			}
-			r.logger.Error(err, "failed to add finalizer to ppr")
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{Requeue: true}, nil
+		return r.addFinalizer(ppr)
 	}
 
-	if !node.Spec.Unschedulable {
-		//the unhealthy node might reboot itself and take new workloads
-		//since we're going to delete the node eventually, we must make sure the node is deleted
-		//when there's no running workload there. Hence we mark it as unschedulable.
+	if !node.Spec.Unschedulable || !utils.TaintExists(node.Spec.Taints, NodeUnschedulableTaint) {
 		return r.markNodeAsUnschedulable(node)
-	}
-
-	if !utils.TaintExists(node.Spec.Taints, NodeUnschedulableTaint) {
-		r.logger.Info("waiting for unschedulable taint to appear", "node name", node.Name)
-		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 
 	if ppr.Status.NodeBackup == nil || ppr.Status.TimeAssumedRebooted.IsZero() {
 		return r.updatePprStatus(node, ppr)
 	}
 
-	maxNodeRebootTime := ppr.Status.TimeAssumedRebooted
+	if r.MyNodeName == node.Name {
+		// we have a problem on this node, reboot!
+		return ctrl.Result{}, r.Rebooter.Reboot()
+	}
 
-	if maxNodeRebootTime.After(time.Now()) {
-		if r.MyNodeName == node.Name {
-			// we have a problem on this node
-			if err := r.Rebooter.Reboot(); err != nil {
-				// re-queue
-				return ctrl.Result{}, err
-			} else {
-				// we are done for now, node will reboot
-				return ctrl.Result{}, nil
-			}
-		}
-		return ctrl.Result{RequeueAfter: maxNodeRebootTime.Sub(time.Now()) + time.Second}, nil
+	wasRebooted, timeLeft := r.wasNodeRebooted(ppr)
+	if !wasRebooted {
+		return ctrl.Result{RequeueAfter: timeLeft}, nil
 	}
 
 	r.logger.Info("TimeAssumedRebooted is old. The unhealthy node assumed to been rebooted", "node name", node.Name)
@@ -263,6 +358,76 @@ func (r *PoisonPillRemediationReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+}
+
+//wasNodeRebooted returns true if the node assumed to been rebooted.
+// if not, it will also return the remaining time for that to happen
+func (r *PoisonPillRemediationReconciler) wasNodeRebooted(ppr *v1alpha1.PoisonPillRemediation) (bool, time.Duration) {
+	maxNodeRebootTime := ppr.Status.TimeAssumedRebooted
+
+	if maxNodeRebootTime.After(time.Now()) {
+		return false, maxNodeRebootTime.Sub(time.Now()) + time.Second
+	}
+
+	return true, 0
+}
+
+//isNodeRebootCapable checks if the node is capable to reboot itself when it becomes unhealthy
+//this boils down to check if it has an assigned poison pill pod, and the reboot-capable annotation
+func (r *PoisonPillRemediationReconciler) isNodeRebootCapable(node *v1.Node) bool {
+	//make sure that the unhealthy node has poison pill pod on it which can reboot it
+	if _, err := utils.GetPoisonPillAgentPod(node.Name, r.Client); err != nil {
+		r.logger.Error(err, "failed to get poison pill agent pod resource")
+		return false
+	}
+
+	//if the unhealthy node has the poison pill agent pod, but the is-reboot-capable annotation is unknown/false/doesn't exist
+	//the node might not reboot, and we might end up in deleting a running node
+	if node.Annotations == nil || node.Annotations[utils.IsRebootCapableAnnotation] != "true" {
+		annVal := ""
+		if node.Annotations != nil {
+			annVal = node.Annotations[utils.IsRebootCapableAnnotation]
+		}
+
+		r.logger.Error(errors.New("node's isRebootCapable annotation is not `true`, which means the node might not reboot when we'll delete the node. Skipping remediation"),
+			"", "annotation value", annVal)
+		return false
+	}
+
+	return true
+}
+
+func (r *PoisonPillRemediationReconciler) removeFinalizer(ppr *v1alpha1.PoisonPillRemediation) error {
+	controllerutil.RemoveFinalizer(ppr, PPRFinalizer)
+	if err := r.Client.Update(context.Background(), ppr); err != nil {
+		if apiErrors.IsConflict(err) {
+			//we don't need to log anything as conflict is expected, but we do want to return an err
+			//to trigger a requeue
+			return err
+		}
+		r.logger.Error(err, "failed to remove finalizer from ppr")
+		return err
+	}
+	return nil
+}
+
+func (r *PoisonPillRemediationReconciler) addFinalizer(ppr *v1alpha1.PoisonPillRemediation) (ctrl.Result, error) {
+	if !ppr.DeletionTimestamp.IsZero() {
+		//ppr is going to be deleted before we started any remediation action, so taking no-op
+		//otherwise we continue the remediation even if the deletionTimestamp is not zero
+		r.logger.Info("ppr is about to be deleted, which means the resource is healthy again. taking no-op")
+		return ctrl.Result{}, nil
+	}
+
+	controllerutil.AddFinalizer(ppr, PPRFinalizer)
+	if err := r.Client.Update(context.Background(), ppr); err != nil {
+		if apiErrors.IsConflict(err) {
+			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+		}
+		r.logger.Error(err, "failed to add finalizer to ppr")
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{Requeue: true}, nil
 }
 
 //returns the lastHeartbeatTime of the first condition, if exists. Otherwise returns the zero value
@@ -367,7 +532,16 @@ func (r *PoisonPillRemediationReconciler) getNodeFromMachine(ref metav1.OwnerRef
 	return node, nil
 }
 
+//the unhealthy node might reboot itself and take new workloads
+//since we're going to delete the node eventually, we must make sure the node is deleted only
+//when there's no running workload there. Hence we mark it as unschedulable.
+//markNodeAsUnschedulable sets node.Spec.Unschedulable which triggers node controller to add the taint
 func (r *PoisonPillRemediationReconciler) markNodeAsUnschedulable(node *v1.Node) (ctrl.Result, error) {
+	if node.Spec.Unschedulable {
+		r.logger.Info("waiting for unschedulable taint to appear", "node name", node.Name)
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+	}
+
 	node.Spec.Unschedulable = true
 	r.logger.Info("Marking node as unschedulable", "node name", node.Name)
 	if err := r.Client.Update(context.Background(), node); err != nil {

--- a/controllers/poisonpillremediation_controller.go
+++ b/controllers/poisonpillremediation_controller.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/fields"
 	"sync"
 	"time"
 
@@ -30,6 +29,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -314,7 +314,6 @@ func (r *PoisonPillRemediationReconciler) remediateWithNodeDeletion(ppr *v1alpha
 		//ppr which states max remediation attempts, and the timeout to consider a remediation failed.
 		return ctrl.Result{}, nil
 	}
-
 
 	if !r.isNodeRebootCapable(node) {
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil

--- a/pkg/utils/uptime.go
+++ b/pkg/utils/uptime.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"golang.org/x/sys/unix"
+	"time"
+)
+
+// GetLinuxUptime returns the uptime of a linux host
+func GetLinuxUptime() (time.Duration, error) {
+	si := &unix.Sysinfo_t{}
+
+	err := unix.Sysinfo(si)
+	if err != nil {
+		return 0, err
+	}
+
+	uptime := time.Duration(si.Uptime) * time.Second
+	return uptime, nil
+}


### PR DESCRIPTION
This is addressing https://github.com/medik8s/poison-pill/issues/103

This PR adds a new remediation strategy to the PPR/PPRT, allowing the user to decide which remediation strategy will be used. By default, we're still going with Node deletion.

The new mode - ResourcesDeletion, has some advantages comparing to node deletion:

1. it should be faster to recover workloads as we directly remove the pods/vas, instead of deleting the node and waiting for some other controller to realize that the pods on that node were deleted.
2. it's less likely to create issues with other 3rd parties, which doesn't take into account the possibility of node being deleted and restored. For example, this will allow OVN users to run poison pill.

Tests will be added in a follow up PR, to avoid making this one too big