### PR TITLE
Return and log error for (invalid) wrong remediation strategy use case

### DIFF
--- a/controllers/poisonpillremediation_controller.go
+++ b/controllers/poisonpillremediation_controller.go
@@ -132,10 +132,12 @@ func (r *PoisonPillRemediationReconciler) Reconcile(ctx context.Context, req ctr
 	case v1alpha1.ResourceDeletionRemediationStrategy:
 		return r.remediateWithResourceDeletion(ppr)
 	default:
-		r.logger.Info("Encountered unsupported remediation strategy. Please check template spec", "strategy", ppr.Spec.RemediationStrategy)
+		//this should never happen since we enforce valid values with kubebuilder
+		err := errors.New("unsupported remediation strategy")
+		r.logger.Error(err, "Encountered unsupported remediation strategy. Please check template spec", "strategy", ppr.Spec.RemediationStrategy)
+		return ctrl.Result{}, err
 	}
 
-	return ctrl.Result{}, nil
 }
 
 func (r *PoisonPillRemediationReconciler) isFencingCompleted(ppr *v1alpha1.PoisonPillRemediation) bool {


### PR DESCRIPTION
We enforce valid options for remediation strategy by kubebuilder, so there shouldn't be a use-case where we get an invalid one.
In case we still do, logging and returning an error (instead of current info message).