### PR TITLE
Update pp sdk version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,14 +192,17 @@ e2e-test:
 	go test ./e2e -ginkgo.v -ginkgo.progress -test.v -timeout 60m -count=1
 
 .PHONY: operator-sdk
-OPERATOR_SDK = ./bin/operator-sdk
+OPERATOR_SDK_VERSION = v1.17.0
+OPERATOR_SDK_BIN_FOLDER = ./bin/operator-sdk
+OPERATOR_SDK = $(OPERATOR_SDK_BIN_FOLDER)/$(OPERATOR_SDK_VERSION)/operator-sdk
 operator-sdk: ## Download operator-sdk locally if necessary.
 ifeq (,$(wildcard $(OPERATOR_SDK)))
 	@{ \
 	set -e ;\
+	rm -rf $(OPERATOR_SDK_BIN_FOLDER) ;\
 	mkdir -p $(dir $(OPERATOR_SDK)) ;\
 	OS=linux && ARCH=amd64 && \
-	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/v1.12.0/operator-sdk_$${OS}_$${ARCH} ;\
+	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
 	chmod +x $(OPERATOR_SDK) ;\
 	}
 endif

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=poison-pill
 LABEL operators.operatorframework.io.bundle.channels.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.11.0+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.16.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/poison-pill.clusterserviceversion.yaml
+++ b/bundle/manifests/poison-pill.clusterserviceversion.yaml
@@ -37,11 +37,11 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     containerImage: quay.io/medik8s/poison-pill-operator:0.1.3
-    createdAt: "2022-02-01 11:56:26"
+    createdAt: "2022-02-14 15:32:01"
     olm.skipRange: '>=0.1.0 <0.3.0'
     operatorframework.io/suggested-namespace: poison-pill
     operators.openshift.io/infrastructure-features: '["disconnected"]'
-    operators.operatorframework.io/builder: operator-sdk-v1.11.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/medik8s/poison-pill
   name: poison-pill.v0.1.3

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: poison-pill
   operators.operatorframework.io.bundle.channels.v1: stable
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.11.0+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.16.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/manifests/bases/poison-pill.clusterserviceversion.yaml
+++ b/config/manifests/bases/poison-pill.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     containerImage: quay.io/medik8s/poison-pill-operator:0.0.0
-    createdAt: "2022-02-01 11:56:26"
+    createdAt: "2022-02-14 15:32:01"
     olm.skipRange: '>=0.1.0 <0.3.0'
     operatorframework.io/suggested-namespace: poison-pill
     operators.openshift.io/infrastructure-features: '["disconnected"]'


### PR DESCRIPTION
This PR is about operator-sdk version PP uses.
It contains couple of changes:

- First Commit
1. operator-sdk version changes from 1.12.0 to 1.17.0
2. making sure that the specified version will be used even if an older version is cached.

-Second commit
Generated bundle files with new sdk