### PR TITLE
remove suggestion namespace

### DIFF
--- a/bundle/manifests/poison-pill.clusterserviceversion.yaml
+++ b/bundle/manifests/poison-pill.clusterserviceversion.yaml
@@ -39,7 +39,6 @@ metadata:
     containerImage: quay.io/medik8s/poison-pill-operator:0.1.3
     createdAt: "2022-02-16 10:41:14"
     olm.skipRange: '>=0.1.0 <0.3.0'
-    operatorframework.io/suggested-namespace: poison-pill
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/config/manifests/bases/poison-pill.clusterserviceversion.yaml
+++ b/config/manifests/bases/poison-pill.clusterserviceversion.yaml
@@ -8,7 +8,6 @@ metadata:
     containerImage: quay.io/medik8s/poison-pill-operator:0.0.0
     createdAt: "2022-02-16 10:41:14"
     olm.skipRange: '>=0.1.0 <0.3.0'
-    operatorframework.io/suggested-namespace: poison-pill
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     repository: https://github.com/medik8s/poison-pill
   name: poison-pill.v0.0.0


### PR DESCRIPTION
Remove suggestion namespace, since Poison Pill is using AllNamespaces installMode.

Signed-off-by: oraz <oraz@redhat.com>