### PR TITLE
[WIP] Split daemonset & manager SA

### DIFF
--- a/bundle/manifests/poison-pill.clusterserviceversion.yaml
+++ b/bundle/manifests/poison-pill.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     containerImage: quay.io/medik8s/poison-pill-operator:0.1.3
-    createdAt: "2022-02-15 17:15:21"
+    createdAt: "2022-03-27 10:14:53"
     olm.skipRange: '>=0.1.0 <0.3.0'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
@@ -170,6 +170,12 @@ spec:
           - update
           - watch
         - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - create
+        - apiGroups:
           - machine.openshift.io
           resources:
           - machines
@@ -267,6 +273,18 @@ spec:
           - get
           - patch
           - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - '*'
         - apiGroups:
           - security.openshift.io
           resourceNames:

--- a/config/manifests/bases/poison-pill.clusterserviceversion.yaml
+++ b/config/manifests/bases/poison-pill.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     containerImage: quay.io/medik8s/poison-pill-operator:0.0.0
-    createdAt: "2022-02-15 17:15:21"
+    createdAt: "2022-03-27 11:50:42"
     olm.skipRange: '>=0.1.0 <0.3.0'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     repository: https://github.com/medik8s/poison-pill

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -60,6 +60,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+- apiGroups:
   - machine.openshift.io
   resources:
   - machines
@@ -157,6 +163,18 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - '*'
 - apiGroups:
   - security.openshift.io
   resourceNames:

--- a/controllers/poisonpillconfig_controller.go
+++ b/controllers/poisonpillconfig_controller.go
@@ -55,6 +55,9 @@ type PoisonPillConfigReconciler struct {
 //+kubebuilder:rbac:groups="security.openshift.io",resources=securitycontextconstraints,verbs=use,resourceNames=privileged
 //+kubebuilder:rbac:groups=machine.openshift.io,resources=machines,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=machine.openshift.io,resources=machines/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups="core",resources=serviceaccounts,verbs=create
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=*
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=create
 
 func (r *PoisonPillConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("poisonpillconfig", req.NamespacedName)

--- a/install/poison-pill-deamonset.yaml
+++ b/install/poison-pill-deamonset.yaml
@@ -21,7 +21,7 @@ spec:
           hostPath:
             path: /dev
             type: Directory
-      serviceAccountName: poison-pill-controller-manager
+      serviceAccountName: poison-pill-daemonset
       priorityClassName: system-node-critical
       hostPID: true
       containers:


### PR DESCRIPTION
At the moment the same SA is used both by the operator and the DS.
The purpose of this PR is to split them and make sure each has the necessary permissions.

- as a first step I'm attempting just to split up the SA while each still have all the permissions (both SA are still connected to the same role). 