### PR TITLE
fix PoisonPillConfig time fields' pattern

### DIFF
--- a/api/v1alpha1/poisonpillconfig_types.go
+++ b/api/v1alpha1/poisonpillconfig_types.go
@@ -48,54 +48,53 @@ type PoisonPillConfigSpec struct {
 	// +kubebuilder:default=180
 	SafeTimeToAssumeNodeRebootedSeconds int `json:"safeTimeToAssumeNodeRebootedSeconds,omitempty"`
 
-	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+	// Valid time units are "ms", "s", "m", "h".
 	// +optional
 	// +kubebuilder:default:="5s"
-	// +kubebuilder:validation:Pattern="^0|([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:Pattern="^(0|([0-9]+(\\.[0-9]+)?(ms|s|m|h)))$"
 	// +kubebuilder:validation:Type:=string
 	PeerApiServerTimeout *metav1.Duration `json:"peerApiServerTimeout,omitempty"`
 
 	// the frequency for api-server connectivity check
-	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+	// Valid time units are "ms", "s", "m", "h".
 	// +optional
 	// +kubebuilder:default:="15s"
-	// +kubebuilder:validation:Pattern="^0|([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:Pattern="^(0|([0-9]+(\\.[0-9]+)?(ms|s|m|h)))$"
 	// +kubebuilder:validation:Type:=string
 	// the frequency for api-server connectivity check
 	ApiCheckInterval *metav1.Duration `json:"apiCheckInterval,omitempty"`
 
-	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+	// Valid time units are "ms", "s", "m", "h".
 	// +optional
 	// +kubebuilder:default:="15m"
-	// +kubebuilder:validation:Pattern="^0|([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:Pattern="^(0|([0-9]+(\\.[0-9]+)?(ms|s|m|h)))$"
 	// +kubebuilder:validation:Type:=string
 	PeerUpdateInterval *metav1.Duration `json:"peerUpdateInterval,omitempty"`
 
-	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+	// Valid time units are "ms", "s", "m", "h".
 	// +optional
 	// +kubebuilder:default:="5s"
-	// +kubebuilder:validation:Pattern="^0|([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:Pattern="^(0|([0-9]+(\\.[0-9]+)?(ms|s|m|h)))$"
 	// +kubebuilder:validation:Type:=string
 	// timeout for each api-connectivity check
 	ApiServerTimeout *metav1.Duration `json:"apiServerTimeout,omitempty"`
 
-	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+	// Valid time units are "ms", "s", "m", "h".
 	// +optional
 	// +kubebuilder:default:="5s"
-	// +kubebuilder:validation:Pattern="^0|([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:Pattern="^(0|([0-9]+(\\.[0-9]+)?(ms|s|m|h)))$"
 	// +kubebuilder:validation:Type:=string
 	// timeout for establishing connection to peer
 	PeerDialTimeout *metav1.Duration `json:"peerDialTimeout,omitempty"`
 
-	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+	// Valid time units are "ms", "s", "m", "h".
 	// +optional
 	// +kubebuilder:default:="5s"
-	// +kubebuilder:validation:Pattern="^0|([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:Pattern="^(0|([0-9]+(\\.[0-9]+)?(ms|s|m|h)))$"
 	// +kubebuilder:validation:Type:=string
 	// timeout for each peer request
 	PeerRequestTimeout *metav1.Duration `json:"peerRequestTimeout,omitempty"`
 
-	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 	// +optional
 	// +kubebuilder:default:=3
 	// +kubebuilder:validation:Minimum=1

--- a/bundle/manifests/poison-pill.medik8s.io_poisonpillconfigs.yaml
+++ b/bundle/manifests/poison-pill.medik8s.io_poisonpillconfigs.yaml
@@ -41,15 +41,15 @@ spec:
               apiCheckInterval:
                 default: 15s
                 description: the frequency for api-server connectivity check Valid
-                  time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". the frequency
-                  for api-server connectivity check
-                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                  time units are "ms", "s", "m", "h". the frequency for api-server
+                  connectivity check
+                pattern: ^(0|([0-9]+(\.[0-9]+)?(ms|s|m|h)))$
                 type: string
               apiServerTimeout:
                 default: 5s
-                description: Valid time units are "ns", "us" (or "µs"), "ms", "s",
-                  "m", "h". timeout for each api-connectivity check
-                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                description: Valid time units are "ms", "s", "m", "h". timeout for
+                  each api-connectivity check
+                pattern: ^(0|([0-9]+(\.[0-9]+)?(ms|s|m|h)))$
                 type: string
               isSoftwareRebootEnabled:
                 default: true
@@ -59,34 +59,31 @@ spec:
                 type: boolean
               maxApiErrorThreshold:
                 default: 3
-                description: Valid time units are "ns", "us" (or "µs"), "ms", "s",
-                  "m", "h". after this threshold, the node will start contacting its
-                  peers
+                description: after this threshold, the node will start contacting
+                  its peers
                 minimum: 1
                 type: integer
               peerApiServerTimeout:
                 default: 5s
-                description: Valid time units are "ns", "us" (or "µs"), "ms", "s",
-                  "m", "h".
-                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                description: Valid time units are "ms", "s", "m", "h".
+                pattern: ^(0|([0-9]+(\.[0-9]+)?(ms|s|m|h)))$
                 type: string
               peerDialTimeout:
                 default: 5s
-                description: Valid time units are "ns", "us" (or "µs"), "ms", "s",
-                  "m", "h". timeout for establishing connection to peer
-                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                description: Valid time units are "ms", "s", "m", "h". timeout for
+                  establishing connection to peer
+                pattern: ^(0|([0-9]+(\.[0-9]+)?(ms|s|m|h)))$
                 type: string
               peerRequestTimeout:
                 default: 5s
-                description: Valid time units are "ns", "us" (or "µs"), "ms", "s",
-                  "m", "h". timeout for each peer request
-                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                description: Valid time units are "ms", "s", "m", "h". timeout for
+                  each peer request
+                pattern: ^(0|([0-9]+(\.[0-9]+)?(ms|s|m|h)))$
                 type: string
               peerUpdateInterval:
                 default: 15m
-                description: Valid time units are "ns", "us" (or "µs"), "ms", "s",
-                  "m", "h".
-                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                description: Valid time units are "ms", "s", "m", "h".
+                pattern: ^(0|([0-9]+(\.[0-9]+)?(ms|s|m|h)))$
                 type: string
               safeTimeToAssumeNodeRebootedSeconds:
                 default: 180

--- a/config/crd/bases/poison-pill.medik8s.io_poisonpillconfigs.yaml
+++ b/config/crd/bases/poison-pill.medik8s.io_poisonpillconfigs.yaml
@@ -43,15 +43,15 @@ spec:
               apiCheckInterval:
                 default: 15s
                 description: the frequency for api-server connectivity check Valid
-                  time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". the frequency
-                  for api-server connectivity check
-                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                  time units are "ms", "s", "m", "h". the frequency for api-server
+                  connectivity check
+                pattern: ^(0|([0-9]+(\.[0-9]+)?(ms|s|m|h)))$
                 type: string
               apiServerTimeout:
                 default: 5s
-                description: Valid time units are "ns", "us" (or "µs"), "ms", "s",
-                  "m", "h". timeout for each api-connectivity check
-                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                description: Valid time units are "ms", "s", "m", "h". timeout for
+                  each api-connectivity check
+                pattern: ^(0|([0-9]+(\.[0-9]+)?(ms|s|m|h)))$
                 type: string
               isSoftwareRebootEnabled:
                 default: true
@@ -61,34 +61,31 @@ spec:
                 type: boolean
               maxApiErrorThreshold:
                 default: 3
-                description: Valid time units are "ns", "us" (or "µs"), "ms", "s",
-                  "m", "h". after this threshold, the node will start contacting its
-                  peers
+                description: after this threshold, the node will start contacting
+                  its peers
                 minimum: 1
                 type: integer
               peerApiServerTimeout:
                 default: 5s
-                description: Valid time units are "ns", "us" (or "µs"), "ms", "s",
-                  "m", "h".
-                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                description: Valid time units are "ms", "s", "m", "h".
+                pattern: ^(0|([0-9]+(\.[0-9]+)?(ms|s|m|h)))$
                 type: string
               peerDialTimeout:
                 default: 5s
-                description: Valid time units are "ns", "us" (or "µs"), "ms", "s",
-                  "m", "h". timeout for establishing connection to peer
-                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                description: Valid time units are "ms", "s", "m", "h". timeout for
+                  establishing connection to peer
+                pattern: ^(0|([0-9]+(\.[0-9]+)?(ms|s|m|h)))$
                 type: string
               peerRequestTimeout:
                 default: 5s
-                description: Valid time units are "ns", "us" (or "µs"), "ms", "s",
-                  "m", "h". timeout for each peer request
-                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                description: Valid time units are "ms", "s", "m", "h". timeout for
+                  each peer request
+                pattern: ^(0|([0-9]+(\.[0-9]+)?(ms|s|m|h)))$
                 type: string
               peerUpdateInterval:
                 default: 15m
-                description: Valid time units are "ns", "us" (or "µs"), "ms", "s",
-                  "m", "h".
-                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                description: Valid time units are "ms", "s", "m", "h".
+                pattern: ^(0|([0-9]+(\.[0-9]+)?(ms|s|m|h)))$
                 type: string
               safeTimeToAssumeNodeRebootedSeconds:
                 default: 180

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/medik8s/poison-pill-operator
-  newTag: 0.1.2-126-g2a69aa1
+  newTag: 0.1.3

--- a/controllers/poisonpillconfig_controller.go
+++ b/controllers/poisonpillconfig_controller.go
@@ -110,12 +110,12 @@ func (r *PoisonPillConfigReconciler) syncConfigDaemonSet(ppc *poisonpillv1alpha1
 	}
 	data.Data["WatchdogPath"] = watchdogPath
 
-	data.Data["PeerApiServerTimeout"] = ppc.Spec.PeerApiServerTimeout.Seconds()
-	data.Data["ApiCheckInterval"] = ppc.Spec.ApiCheckInterval.Seconds()
-	data.Data["PeerUpdateInterval"] = ppc.Spec.PeerUpdateInterval.Seconds()
-	data.Data["ApiServerTimeout"] = ppc.Spec.ApiServerTimeout.Seconds()
-	data.Data["PeerDialTimeout"] = ppc.Spec.PeerDialTimeout.Seconds()
-	data.Data["PeerRequestTimeout"] = ppc.Spec.PeerRequestTimeout.Seconds()
+	data.Data["PeerApiServerTimeout"] = ppc.Spec.PeerApiServerTimeout.Nanoseconds()
+	data.Data["ApiCheckInterval"] = ppc.Spec.ApiCheckInterval.Nanoseconds()
+	data.Data["PeerUpdateInterval"] = ppc.Spec.PeerUpdateInterval.Nanoseconds()
+	data.Data["ApiServerTimeout"] = ppc.Spec.ApiServerTimeout.Nanoseconds()
+	data.Data["PeerDialTimeout"] = ppc.Spec.PeerDialTimeout.Nanoseconds()
+	data.Data["PeerRequestTimeout"] = ppc.Spec.PeerRequestTimeout.Nanoseconds()
 	data.Data["MaxApiErrorThreshold"] = ppc.Spec.MaxApiErrorThreshold
 
 	timeToAssumeNodeRebooted := ppc.Spec.SafeTimeToAssumeNodeRebootedSeconds

--- a/main.go
+++ b/main.go
@@ -163,7 +163,7 @@ func initPoisonPillManager(mgr manager.Manager) {
 
 func getDurEnvVarOrDie(varName string) time.Duration {
 	intVar := getIntEnvVarOrDie(varName)
-	return time.Duration(intVar) * time.Second
+	return time.Duration(intVar)
 }
 
 func getIntEnvVarOrDie(varName string) int {


### PR DESCRIPTION
Change pattern to enable only one time unit and no units smaller than ms. Change the time saved in the DS env var to be nanoseconds (smallest time unit) so it would always be an int and not float (otherwise getDurEnvVarOrDie will fail).