### PR TITLE
Setting version to 0.3.1

### DIFF
--- a/bundle/manifests/poison-pill.clusterserviceversion.yaml
+++ b/bundle/manifests/poison-pill.clusterserviceversion.yaml
@@ -37,8 +37,8 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     containerImage: quay.io/medik8s/poison-pill-operator:0.1.3
-    createdAt: "2022-02-16 10:41:14"
-    olm.skipRange: '>=0.1.0 <0.3.0'
+    createdAt: "2022-04-26 13:48:38"
+    olm.skipRange: '>=0.1.0 <0.3.1'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/config/manifests/bases/poison-pill.clusterserviceversion.yaml
+++ b/config/manifests/bases/poison-pill.clusterserviceversion.yaml
@@ -6,8 +6,8 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     containerImage: quay.io/medik8s/poison-pill-operator:0.0.0
-    createdAt: "2022-02-16 10:41:14"
-    olm.skipRange: '>=0.1.0 <0.3.0'
+    createdAt: "2022-04-26 13:48:38"
+    olm.skipRange: '>=0.1.0 <0.3.1'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     repository: https://github.com/medik8s/poison-pill
   name: poison-pill.v0.0.0


### PR DESCRIPTION
This PR is the upstream preparation for the 0.3.1 downstream Poison Pill Version which will limit Poison Pill to OCP 4.10 or older.